### PR TITLE
Site admin tokens should be able to access any policies in OPA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ RUN pip install --no-cache-dir -r app/tests/requirements.txt
 
 ARG client_id
 ENV CLIENT_ID=${client_id}
-RUN sed -i s/CLIENT_ID/$CLIENT_ID/ app/permissions_engine/idp.rego
+RUN sed -i s/CLIENT_ID/$CLIENT_ID/ app/permissions_engine/idp.rego && sed -i s/CLIENT_ID/$CLIENT_ID/ app/permissions_engine/authz.rego
+
+ARG opa_site_admin_key
+ENV OPA_SITE_ADMIN_KEY=${opa_site_admin_key}
+RUN sed -i s/OPA_SITE_ADMIN_KEY/$OPA_SITE_ADMIN_KEY/ app/permissions_engine/idp.rego && sed -i s/OPA_SITE_ADMIN_KEY/$OPA_SITE_ADMIN_KEY/ app/permissions_engine/authz.rego
 
 ENTRYPOINT ["top", "-b"]

--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -49,3 +49,19 @@ identity_rights[right] {             # Right is in the identity_rights set if...
     role := token.roles[_]           # Token has a role, and...
     right := rights[role]            # Role has rights defined.
 }
+
+allow {
+    decode_verify_token_output[2].OPA_SITE_ADMIN_KEY
+}
+
+decode_verify_token_output = output{
+    some i
+    output:=io.jwt.decode_verify(     # Decode and verify in one-step
+            input.identity,
+            {                         # With the supplied constraints:
+                "cert": data.keys[i].cert,
+                "iss": data.keys[i].iss,
+                "aud": "CLIENT_ID"
+            }
+    )
+}

--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -50,6 +50,13 @@ identity_rights[right] {             # Right is in the identity_rights set if...
     right := rights[role]            # Role has rights defined.
 }
 
+# If token is valid, allow only the datasets path
+allow {
+    decode_verify_token_output
+    input.path == rights["datasets"]["path"]
+}
+
+# If token payload has OPA_SITE_ADMIN_KEY in it, allow always
 allow {
     decode_verify_token_output[2].OPA_SITE_ADMIN_KEY
 }

--- a/permissions_engine/fetch_keys.py
+++ b/permissions_engine/fetch_keys.py
@@ -5,14 +5,13 @@ import os
 IDP = os.getenv("IDP")
 
 data = dict()
-data["keys"] = dict()
+data["keys"] = []
 issuers = [IDP]
 
 for external in issuers:
     response = requests.get(external + "/.well-known/openid-configuration")
     json_data = json.loads(response.text)
     jwks = requests.get(json_data["jwks_uri"]).text
-    data["keys"][external] = jwks
-
+    data["keys"].append({"iss": external, "cert": jwks})
 with open('/app/data.json', 'w') as f:
     json.dump(data, f)

--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -14,8 +14,6 @@ decode_verify_token_output = output{
                 "aud": "CLIENT_ID"
             }
     )
-    valid = output[0]
-    valid == true
 }
 
 #

--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -2,23 +2,16 @@ package idp
 # for interacting with the IdP
 
 #
-# Configuration
-#
-
-audience := ["account", "portal", "CLIENT_ID"]
-key_sets = data.keys
-
-#
 # Store decode and verified token
 #
 decode_verify_token_output = output{
-	some iss
+	some i
     output:=io.jwt.decode_verify(     # Decode and verify in one-step
             input.token,
-            {                                                 # With the supplied constraints:
-                "cert": key_sets[iss],
-                "iss": iss,
-                "aud": audience[2]
+            {                         # With the supplied constraints:
+                "cert": data.keys[i].cert,
+                "iss": data.keys[i].iss,
+                "aud": "CLIENT_ID"
             }
     )
     valid = output[0]

--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -31,4 +31,12 @@ trusted_researcher = true {
     decode_verify_token_output[2].trusted_researcher == true        
 }
 
+#
+# Check OPA_SITE_ADMIN_KEY in the token payload
+#
+OPA_SITE_ADMIN_KEY = true {
+    decode_verify_token_output[0]
+    decode_verify_token_output[2].OPA_SITE_ADMIN_KEY == true        
+}
+
 username := decode_verify_token_output[2].preferred_username        # get username from the token payload

--- a/permissions_engine/permissions.rego
+++ b/permissions_engine/permissions.rego
@@ -5,12 +5,6 @@ package permissions
 
 default datasets = []
 
-open_datasets = data.access.open_datasets
-registered_datasets = data.access.registered_datasets
-
-controlled_access_list = data.access.controlled_access_list
-opt_in_datasets = data.access.opt_in_datasets
-
 input_paths = array.concat(array.concat(data.paths.katsu, data.paths.htsget), data.paths.candigv1)
 
 #
@@ -21,7 +15,6 @@ input_paths = array.concat(array.concat(data.paths.katsu, data.paths.htsget), da
 #     'path': path to request at data service
 # }
 #
-
 import data.idp.valid_token
 import data.idp.trusted_researcher
 import data.idp.username
@@ -33,7 +26,7 @@ import data.idp.username
 
 default registered_allowed = []
 
-registered_allowed = registered_datasets {
+registered_allowed = data.access.registered_datasets {
     valid_token         # extant, valid token
     trusted_researcher  # has claim we're using for registered access
 }
@@ -44,7 +37,7 @@ registered_allowed = registered_datasets {
 
 default controlled_allowed = []
 
-controlled_allowed = controlled_access_list[username]{
+controlled_allowed = data.access.controlled_access_list[username]{
     valid_token                  # extant, valid token
 }
 
@@ -53,14 +46,14 @@ controlled_allowed = controlled_access_list[username]{
 #
 
 # allowed datasets
-datasets = array.concat(array.concat(open_datasets, registered_allowed), controlled_allowed) 
+datasets = array.concat(array.concat(data.access.open_datasets, registered_allowed), controlled_allowed) 
 {
     input.body.method = "GET"                   # only allow GET requests
     regex.match(input_paths[_], input.body.path) == true
 }
 
 # allowed datasets for counting
-datasets = array.concat(open_datasets, opt_in_datasets) {
+datasets = array.concat(data.access.open_datasets, data.access.opt_in_datasets) {
     valid_token == true
     input.method = "GET"
     regex.match(input_paths[_], input.body.path) == true


### PR DESCRIPTION
If you run `make clean-authx` and `make init-authx`, you should then be able to do the following tests:

User1 and user2 should act as before for this:
```
$ curl -X "POST" "http://docker.localhost:8181/v1/data/permissions/datasets" \
     -H 'Authorization: Bearer <token>' \
     -H 'Content-Type: application/json' \
     -H 'Accept: application/json' \
     -d $'{
  "input": {
    "token": <token>,
    "body": {
      "path": "/api/mcodepackets",
      "method": "GET"
    }
  }
}'

>> user1: {"result":["open1","open2","dataset_3","registered3","controlled4","mock1"]}
>> user2: {"result":["open1","open2","dataset_3","controlled5"]}
```

User2 should be able to get results for this, but not user1:
```
$ curl -X "POST" "http://docker.localhost:8181/v1/data/idp/site_admin" \
     -H 'Authorization: Bearer <token>\
     -H 'Content-Type: application/json' \
     -H 'Accept: application/json' \
     -d $'{
  "input": {
    "token": "<token>"
  }
}'

>> user1: {
  "code": "unauthorized",
  "message": "request rejected by administrative policy"
}
>> user2: {"result":true}
```