### PR TITLE
use realm_access role to give site admin status

### DIFF
--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -15,7 +15,7 @@ rights = {
     }
 }
 
-# Tokens provided asn env variables
+# Tokens provided as env variables
 
 env := opa.runtime().env
 root_token := object.get(env, "CLIENT_SECRET_ROOT", "no_root_token")
@@ -58,7 +58,8 @@ allow {
 
 # If token payload has OPA_SITE_ADMIN_KEY in it, allow always
 allow {
-    decode_verify_token_output[2].OPA_SITE_ADMIN_KEY
+    some i
+    decode_verify_token_output[2].realm_access.roles[i] == "OPA_SITE_ADMIN_KEY"
 }
 
 decode_verify_token_output = output{

--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -36,7 +36,8 @@ trusted_researcher = true {
 #
 OPA_SITE_ADMIN_KEY = true {
     decode_verify_token_output[0]
-    decode_verify_token_output[2].OPA_SITE_ADMIN_KEY == "true"
+    some i
+    decode_verify_token_output[2].realm_access.roles[i] == "OPA_SITE_ADMIN_KEY"
 }
 
 username := decode_verify_token_output[2].preferred_username        # get username from the token payload


### PR DESCRIPTION
We just change where we're looking for OPA_SITE_ADMIN_KEY: it's now a role that is assigned to a user. You can create the role in the keycloak admin console under Roles: just add a role named "site_admin" or whatever OPA_SITE_ADMIN_KEY is. Then add the role to user2.

When you get user2's bearer token and then do
```
curl -X "POST" "https://candig.uhnresearch.ca/policy/v1/data/idp/site_admin" \
     -H 'Authorization: Bearer <token> \
     -H 'Content-Type: application/json' \
     -H 'Accept: application/json' \
     -d $'{
  "input": {
    "token": <token>
  }
}'
```
you should get result = true. Other users should give you no result.

This has already been implemented on prod for user2.