### PR TITLE
Tweaks for htsget

### DIFF
--- a/permissions_engine/access.json
+++ b/permissions_engine/access.json
@@ -2,8 +2,7 @@
     "access": {
         "open_datasets": [
             "open1",
-            "open2",
-            "dataset_3"
+            "open2"
         ],
         "registered_datasets": [
             "registered3"

--- a/permissions_engine/paths.json
+++ b/permissions_engine/paths.json
@@ -56,7 +56,8 @@
                 
             ],
             "htsget": [
-                "/htsget/v1/variants/search"
+                "/htsget/v1/variants/search",
+                "/htsget/v1/variants/?.*/index"
             ]
         }
     }

--- a/permissions_engine/paths.json
+++ b/permissions_engine/paths.json
@@ -1,50 +1,63 @@
 {
     "paths": {
-        "katsu": [
-            "/api/phenopackets/?.*",
-            "/api/datasets/?.*",
-            "/api/diagnoses/?.*",
-            "/api/diseases/?.*",
-            "/api/genes/?.*",
-            "/api/genomicinterpretations/?.*",
-            "/api/htsfiles/?.*",
-            "/api/individuals/?.*",
-            "/api/interpretations/?.*",
-            "/api/metadata/?.*",
-            "/api/phenopackets/?.*",
-            "/api/phenotypicfeatures/?.*",
-            "/api/procedures/?.*",
-            "/api/variants/?.*",
-            "/api/biosamples/?.*",
-            "/api/overview",
-            "/api/mcodepackets/?.*",
-            "/api/medicationstatements/?.*",
-            "/api/cancerrelatedprocedures/?.*",
-            "/api/tnmstaging/?.*",
-            "/api/cancerconditions/?.*",
-            "/api/labsvital/?.*",
-            "/api/genomicsreports/?.*",
-            "/api/genomicregionsstudied/?.*",
-            "/api/cancergeneticvariants/?.*",
-            "/api/geneticspecimens/?.*"
-        ],
-        "htsget": [
-            "/htsget/v1/variants/?.*",
-            "/htsget/v1/reads/?.*",
-            "/ga4gh/drs/v1/objects/?.*"
-        ],
-        "candigv1": [
-            "/patients/search/?.*",
-            "/datasets/search/?.*",
-            "/count/?.*",
-            "/variants/search/?.*",
-            "/variants/beacon/range/search/?.*",
-            "/variants/beacon/allele/freq/search/?.*",
-            "/variantsets/search/?.*",
-            "/readgroupsets/search/?.*",
-            "/featuresets/search/?.*",
-            "/reads/search/?.*",
-            "/referencesets/?.*"
-        ]
-	}
+        "get": {
+            "katsu": [
+                "/api/phenopackets/?.*",
+                "/api/datasets/?.*",
+                "/api/diagnoses/?.*",
+                "/api/diseases/?.*",
+                "/api/genes/?.*",
+                "/api/genomicinterpretations/?.*",
+                "/api/htsfiles/?.*",
+                "/api/individuals/?.*",
+                "/api/interpretations/?.*",
+                "/api/metadata/?.*",
+                "/api/phenopackets/?.*",
+                "/api/phenotypicfeatures/?.*",
+                "/api/procedures/?.*",
+                "/api/variants/?.*",
+                "/api/biosamples/?.*",
+                "/api/overview",
+                "/api/mcodepackets/?.*",
+                "/api/medicationstatements/?.*",
+                "/api/cancerrelatedprocedures/?.*",
+                "/api/tnmstaging/?.*",
+                "/api/cancerconditions/?.*",
+                "/api/labsvital/?.*",
+                "/api/genomicsreports/?.*",
+                "/api/genomicregionsstudied/?.*",
+                "/api/cancergeneticvariants/?.*",
+                "/api/geneticspecimens/?.*"
+            ],
+            "htsget": [
+                "/htsget/v1/variants/?.*",
+                "/htsget/v1/variants/search",
+                "/htsget/v1/variants/?.*/index",
+                "/htsget/v1/reads/?.*",
+                "/ga4gh/drs/v1/objects/?.*",
+                "/ga4gh/drs/v1/datasets/?.*"
+            ],
+            "candigv1": [
+                "/patients/search/?.*",
+                "/datasets/search/?.*",
+                "/count/?.*",
+                "/variants/search/?.*",
+                "/variants/beacon/range/search/?.*",
+                "/variants/beacon/allele/freq/search/?.*",
+                "/variantsets/search/?.*",
+                "/readgroupsets/search/?.*",
+                "/featuresets/search/?.*",
+                "/reads/search/?.*",
+                "/referencesets/?.*"
+            ]
+        },
+        "post": {
+            "katsu": [
+                
+            ],
+            "htsget": [
+                "/htsget/v1/variants/search"
+            ]
+        }
+    }
 }

--- a/permissions_engine/permissions.rego
+++ b/permissions_engine/permissions.rego
@@ -5,7 +5,8 @@ package permissions
 
 default datasets = []
 
-input_paths = array.concat(array.concat(data.paths.katsu, data.paths.htsget), data.paths.candigv1)
+get_input_paths = array.concat(array.concat(data.paths.get.katsu, data.paths.get.htsget), data.paths.get.candigv1)
+post_input_paths = array.concat(data.paths.post.katsu, data.paths.post.htsget)
 
 #
 # Provided: 
@@ -48,14 +49,20 @@ controlled_allowed = data.access.controlled_access_list[username]{
 # allowed datasets
 datasets = array.concat(array.concat(data.access.open_datasets, registered_allowed), controlled_allowed) 
 {
-    input.body.method = "GET"                   # only allow GET requests
-    regex.match(input_paths[_], input.body.path) == true
+    input.body.method = "GET"
+    regex.match(get_input_paths[_], input.body.path) == true
+}
+
+datasets = array.concat(array.concat(data.access.open_datasets, registered_allowed), controlled_allowed) 
+{
+    input.body.method = "POST"
+    regex.match(post_input_paths[_], input.body.path) == true
 }
 
 # allowed datasets for counting
 datasets = array.concat(data.access.open_datasets, data.access.opt_in_datasets) {
     valid_token == true
     input.method = "GET"
-    regex.match(input_paths[_], input.body.path) == true
+    regex.match(get_input_paths[_], input.body.path) == true
     input.query_type = "counts"
 }


### PR DESCRIPTION
Moved around some paths so that we can add more POST paths in a more organized fashion.

If you merge https://github.com/CanDIG/htsget_app/pull/228 for htsget, you can then actually reach the /genomics/htsget/v1/variants/search and index paths through tyk.