### PR TITLE
DIG-1000: remove valid token access to datasets

### DIFF
--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -49,12 +49,6 @@ identity_rights[right] {             # Right is in the identity_rights set if...
     right := rights[role]            # Role has rights defined.
 }
 
-# If token is valid, allow only the datasets path
-allow {
-    decode_verify_token_output
-    input.path == rights["datasets"]["path"]
-}
-
 # If token payload has OPA_SITE_ADMIN_KEY in it, allow always
 allow {
     some i


### PR DESCRIPTION
Before this change, any valid user token could request the authorized datasets that correspond to any given bearer token's user:

```
curl -X "POST" "http://docker.localhost:5080/policy/v1/data/permissions/datasets" \
     -H 'Authorization: Bearer <user1 token>' \
     -H 'Content-Type: application/json' \
     -H 'Accept: application/json' \
     -d $'{
  "input": {
    "token": <user2 token>,
    "body": {
      "path": "/api/datasets",
      "method": "GET"
    }
  }
}'

{
  "result": [
    "open1",
    "open2",
    "controlled5"
  ]
}
```

Now it will return 
```
{
  "code": "unauthorized",
  "message": "request rejected by administrative policy"
}
```
unless you pass in either a header with the authorization token for a site admin or a header `X-Opa` with the value of OPA_SECRET (which can be either the value in CanDIGv2/tmp/secrets/opa-root-token or opa-service-token)