### PR TITLE
Need to have consistency between permissions.rego and paths.json

### DIFF
--- a/permissions_engine/paths.json
+++ b/permissions_engine/paths.json
@@ -14,6 +14,7 @@
             ]
         },
         "post": {
+            "katsu": [],
             "htsget": [
                 "/htsget/v1/variants/search",
                 "/htsget/v1/variants/?.*/index"

--- a/permissions_engine/paths.json
+++ b/permissions_engine/paths.json
@@ -1,24 +1,17 @@
 {
     "paths": {
         "get": {
-            "katsu": [
-                "/api/v1/moh/?.*"
-            ],
-            "htsget": [
-                "/htsget/v1/variants/?.*",
-                "/htsget/v1/variants/search",
-                "/htsget/v1/variants/?.*/index",
-                "/htsget/v1/reads/?.*",
-                "/ga4gh/drs/v1/objects/?.*",
-                "/ga4gh/drs/v1/datasets/?.*"
-            ]
+            "/api/v1/moh/?.*",
+            "/htsget/v1/variants/?.*",
+            "/htsget/v1/variants/search",
+            "/htsget/v1/variants/?.*/index",
+            "/htsget/v1/reads/?.*",
+            "/ga4gh/drs/v1/objects/?.*",
+            "/ga4gh/drs/v1/datasets/?.*"
         },
         "post": {
-            "katsu": [],
-            "htsget": [
-                "/htsget/v1/variants/search",
-                "/htsget/v1/variants/?.*/index"
-            ]
+            "/htsget/v1/variants/search",
+            "/htsget/v1/variants/?.*/index"
         }
     }
 }

--- a/permissions_engine/paths.json
+++ b/permissions_engine/paths.json
@@ -1,6 +1,6 @@
 {
     "paths": {
-        "get": {
+        "get": [
             "/api/v1/moh/?.*",
             "/htsget/v1/variants/?.*",
             "/htsget/v1/variants/search",
@@ -8,10 +8,10 @@
             "/htsget/v1/reads/?.*",
             "/ga4gh/drs/v1/objects/?.*",
             "/ga4gh/drs/v1/datasets/?.*"
-        },
-        "post": {
+        ],
+        "post": [
             "/htsget/v1/variants/search",
             "/htsget/v1/variants/?.*/index"
-        }
+        ]
     }
 }

--- a/permissions_engine/permissions.rego
+++ b/permissions_engine/permissions.rego
@@ -5,8 +5,8 @@ package permissions
 
 default datasets = []
 
-get_input_paths = array.concat(data.paths.get.katsu, data.paths.get.htsget)
-post_input_paths = array.concat(data.paths.post.katsu, data.paths.post.htsget)
+get_input_paths = data.paths.get
+post_input_paths = data.paths.post
 
 #
 # Provided: 
@@ -47,13 +47,13 @@ controlled_allowed = data.access.controlled_access_list[email]{
 #
 
 # allowed datasets
-datasets = array.concat(array.concat(data.access.open_datasets, registered_allowed), controlled_allowed) 
+datasets = array.concat(array.concat(data.access.open_datasets, registered_allowed), controlled_allowed)
 {
     input.body.method = "GET"
     regex.match(get_input_paths[_], input.body.path) == true
 }
 
-datasets = array.concat(array.concat(data.access.open_datasets, registered_allowed), controlled_allowed) 
+datasets = array.concat(array.concat(data.access.open_datasets, registered_allowed), controlled_allowed)
 {
     input.body.method = "POST"
     regex.match(post_input_paths[_], input.body.path) == true

--- a/permissions_engine/permissions.rego
+++ b/permissions_engine/permissions.rego
@@ -5,7 +5,7 @@ package permissions
 
 default datasets = []
 
-get_input_paths = array.concat(array.concat(data.paths.get.katsu, data.paths.get.htsget), data.paths.get.candigv1)
+get_input_paths = array.concat(data.paths.get.katsu, data.paths.get.htsget)
 post_input_paths = array.concat(data.paths.post.katsu, data.paths.post.htsget)
 
 #


### PR DESCRIPTION
Paths.json and permissions.rego need to match, in terms of what keys are present.

For whatever reason, you need to delete the shared external docker volume opa-data, then recreate it:
```
make docker-volumes
make build-opa
make compose-opa
```

Then the following should work:

```## opa datasets NO TYK
curl -X "POST" "http://docker.localhost:8181/v1/data/permissions/datasets" \
     -H 'Content-Type: application/json' \
     -H 'Accept: application/json' \
     -H 'X-Opa: <opa-root-token>' \
     -d $'{
  "input": {
    "token": <user1 token>,
    "body": {
      "path": "/htsget/v1/variants",
      "method": "GET"
    }
  }
}'
```
should now return ```{
  "result": [
    "open1",
    "open2",
    "registered3",
    "controlled4",
    "mock1"
  ]
}```
