### PR TITLE
DIG-1165: fix var safety issue

### DIFF
--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -56,11 +56,13 @@ allow {
 
 decode_verify_token_output[issuer] := output {
     some i
+    issuer := data.keys[i].iss
+    cert := data.keys[i].cert
     output := io.jwt.decode_verify(     # Decode and verify in one-step
         input.identity,
         {                         # With the supplied constraints:
-            "cert": data.keys[i].cert,
-            "iss": data.keys[i].iss,
+            "cert": cert,
+            "iss": issuer,
             "aud": "CLIENT_ID"
         }
     )

--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -6,11 +6,13 @@ package idp
 #
 decode_verify_token_output[issuer] := output {
     some i
+    issuer := data.keys[i].iss
+    cert := data.keys[i].cert
     output := io.jwt.decode_verify(     # Decode and verify in one-step
         input.token,
         {                         # With the supplied constraints:
-            "cert": data.keys[i].cert,
-            "iss": data.keys[i].iss,
+            "cert": cert,
+            "iss": issuer,
             "aud": "CLIENT_ID"
         }
     )


### PR DESCRIPTION
I had oversimplified the code and made the var `issuer` too broad, apparently: https://www.openpolicyagent.org/docs/latest/faq/#safety

Delete the opa and opa-runner containers, then delete the opa-data volume. Then run:
```
make docker-volumes
make build-opa
make compose-opa
```

and verify that 
```
docker exec candigv2_opa-runner_1 more /app/permissions_engine/idp.rego
```

has the changes. Opa should run correctly now.