### PR TITLE
Update paths.json

### DIFF
--- a/permissions_engine/paths.json
+++ b/permissions_engine/paths.json
@@ -1,7 +1,7 @@
 {
     "paths": {
         "get": [
-            "/moh/v1/?.*",
+            "/moh/v2/?.*",
             "/htsget/v1/variants/?.*",
             "/htsget/v1/variants/search",
             "/htsget/v1/variants/?.*/index",

--- a/permissions_engine/paths.json
+++ b/permissions_engine/paths.json
@@ -1,7 +1,7 @@
 {
     "paths": {
         "get": [
-            "/moh/v2/?.*",
+            "/katsu/v2/?.*",
             "/htsget/v1/variants/?.*",
             "/htsget/v1/variants/search",
             "/htsget/v1/variants/?.*/index",

--- a/permissions_engine/paths.json
+++ b/permissions_engine/paths.json
@@ -1,14 +1,15 @@
 {
     "paths": {
         "get": [
-            "/katsu/v2/?.*",
-            "/htsget/v1/variants/?.*",
-            "/htsget/v1/variants/search",
-            "/htsget/v1/variants/?.*/index",
-            "/htsget/v1/reads/?.*",
-            "/ga4gh/drs/v1/objects/?.*",
-            "/ga4gh/drs/v1/datasets/?.*",
-            "/beacon/v2/g_variants/?.*"
+          "/v2/discovery/?.*",
+          "/v2/authorized/?.*",
+          "/htsget/v1/variants/?.*",
+          "/htsget/v1/variants/search",
+          "/htsget/v1/variants/?.*/index",
+          "/htsget/v1/reads/?.*",
+          "/ga4gh/drs/v1/objects/?.*",
+          "/ga4gh/drs/v1/datasets/?.*",
+          "/beacon/v2/g_variants/?.*"
         ],
         "post": [
             "/htsget/v1/variants/search",


### PR DESCRIPTION
What's new:
- update katsu path to v2

How to test:
1. Clean the previous OPA:
```
docker rm -f candigv2_opa-runner_1
docker rm -f candigv2_opa_1
docker rmi candigv2_opa-runner:latest
docker rmi openpolicyagent/opa:0.52.0-static
docker volume rm opa-data
```
2. Rebuild OPA
```
docker volume create opa-data --label candigv2=volume
make build-opa
make compose-opa
```