### PR TITLE
DIG-1318: Opa startup only registers its own token

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 set -Euo pipefail
 
 if [[ -f "initial_setup" ]]; then
-    sed -i s/CLIENT_ID/$IDP_CLIENT_ID/ app/permissions_engine/idp.rego && sed -i s/CLIENT_ID/$IDP_CLIENT_ID/ app/permissions_engine/authz.rego
+    sed -i s/CLIENT_ID/$KEYCLOAK_CLIENT_ID/ app/permissions_engine/idp.rego && sed -i s/CLIENT_ID/$KEYCLOAK_CLIENT_ID/ app/permissions_engine/authz.rego
     sed -i s/OPA_SITE_ADMIN_KEY/$OPA_SITE_ADMIN_KEY/ app/permissions_engine/idp.rego && sed -i s/OPA_SITE_ADMIN_KEY/$OPA_SITE_ADMIN_KEY/ app/permissions_engine/authz.rego
 
     OPA_SERVICE_TOKEN=$(cat /run/secrets/opa-service-token)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,14 +5,14 @@ set -Euo pipefail
 if [[ -f "initial_setup" ]]; then
     sed -i s/CLIENT_ID/$IDP_CLIENT_ID/ app/permissions_engine/idp.rego && sed -i s/CLIENT_ID/$IDP_CLIENT_ID/ app/permissions_engine/authz.rego
     sed -i s/OPA_SITE_ADMIN_KEY/$OPA_SITE_ADMIN_KEY/ app/permissions_engine/idp.rego && sed -i s/OPA_SITE_ADMIN_KEY/$OPA_SITE_ADMIN_KEY/ app/permissions_engine/authz.rego
-    
+
     OPA_SERVICE_TOKEN=$(cat /run/secrets/opa-service-token)
     sed -i s/OPA_SERVICE_TOKEN/$OPA_SERVICE_TOKEN/ app/permissions_engine/authz.rego
 
     OPA_ROOT_TOKEN=$(cat /run/secrets/opa-root-token)
     sed -i s/OPA_ROOT_TOKEN/$OPA_ROOT_TOKEN/ app/permissions_engine/authz.rego
 
-    python3 app/permissions_engine/fetch_keys.py
+    python3 app/permissions_engine/initialize_idp.py
     rm initial_setup
 fi
 

--- a/permissions_engine/fetch_keys.py
+++ b/permissions_engine/fetch_keys.py
@@ -2,16 +2,14 @@ import requests
 import json
 import os
 
-IDP = os.getenv("IDP")
+MY_KEYCLOAK_REALM = os.getenv("KEYCLOAK_REALM_URL")
 
 data = dict()
 data["keys"] = []
-issuers = [IDP]
 
-for external in issuers:
-    response = requests.get(external + "/.well-known/openid-configuration")
-    json_data = json.loads(response.text)
-    jwks = requests.get(json_data["jwks_uri"]).text
-    data["keys"].append({"iss": external, "cert": jwks})
+response = requests.get(MY_KEYCLOAK_REALM + "/.well-known/openid-configuration")
+json_data = json.loads(response.text)
+jwks = requests.get(json_data["jwks_uri"]).text
+data["keys"].append({"iss": MY_KEYCLOAK_REALM, "cert": jwks})
 with open('/app/data.json', 'w') as f:
     json.dump(data, f)

--- a/permissions_engine/initialize_idp.py
+++ b/permissions_engine/initialize_idp.py
@@ -2,6 +2,7 @@ import requests
 import json
 import os
 
+# Initializes Opa's list of known IDPs (keys) with our own Keycloak instance's information.
 MY_KEYCLOAK_REALM = os.getenv("KEYCLOAK_REALM_URL")
 
 data = dict()


### PR DESCRIPTION
Along with a soon-to-be created CanDIGv2 PR, this one makes sure that the first IDP registered by the Opa container on creation is its own keycloak instance.

I also renamed a few things for clarity. `fetch_keys.py` is now `initialize_idp.py`, since it only initializes the one IDP, and I took the non-functional loop out of the code.