### PR TITLE
DIG-1377: Be consistent in our use of candig user inside containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,6 @@ RUN chown -R candig:candig /app
 
 USER candig
 
-RUN touch initial_setup
+RUN touch /app/initial_setup
 
 ENTRYPOINT ["bash", "/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ COPY ./ /app/
 
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
+WORKDIR /app/
+
 RUN chown -R candig:candig /app
 
 USER candig

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ LABEL "candigv2"="opa"
 
 USER root
 
+RUN addgroup -S candig && adduser -S candig -G candig
+
 RUN apk update
 
 RUN apk add --no-cache \
@@ -19,5 +21,10 @@ COPY ./ /app/
 
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
+RUN chown -R candig:candig /app
+
+USER candig
+
 RUN touch initial_setup
+
 ENTRYPOINT ["bash", "/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,18 +2,18 @@
 
 set -Euo pipefail
 
-if [[ -f "initial_setup" ]]; then
-    sed -i s/CLIENT_ID/$KEYCLOAK_CLIENT_ID/ app/permissions_engine/idp.rego && sed -i s/CLIENT_ID/$KEYCLOAK_CLIENT_ID/ app/permissions_engine/authz.rego
-    sed -i s/OPA_SITE_ADMIN_KEY/$OPA_SITE_ADMIN_KEY/ app/permissions_engine/idp.rego && sed -i s/OPA_SITE_ADMIN_KEY/$OPA_SITE_ADMIN_KEY/ app/permissions_engine/authz.rego
+if [[ -f "/app/initial_setup" ]]; then
+    sed -i s/CLIENT_ID/$KEYCLOAK_CLIENT_ID/ /app/permissions_engine/idp.rego && sed -i s/CLIENT_ID/$KEYCLOAK_CLIENT_ID/ /app/permissions_engine/authz.rego
+    sed -i s/OPA_SITE_ADMIN_KEY/$OPA_SITE_ADMIN_KEY/ /app/permissions_engine/idp.rego && sed -i s/OPA_SITE_ADMIN_KEY/$OPA_SITE_ADMIN_KEY/ /app/permissions_engine/authz.rego
 
     OPA_SERVICE_TOKEN=$(cat /run/secrets/opa-service-token)
-    sed -i s/OPA_SERVICE_TOKEN/$OPA_SERVICE_TOKEN/ app/permissions_engine/authz.rego
+    sed -i s/OPA_SERVICE_TOKEN/$OPA_SERVICE_TOKEN/ /app/permissions_engine/authz.rego
 
     OPA_ROOT_TOKEN=$(cat /run/secrets/opa-root-token)
-    sed -i s/OPA_ROOT_TOKEN/$OPA_ROOT_TOKEN/ app/permissions_engine/authz.rego
-
-    python3 app/permissions_engine/initialize_idp.py
-    rm initial_setup
+    sed -i s/OPA_ROOT_TOKEN/$OPA_ROOT_TOKEN/ /app/permissions_engine/authz.rego
+    echo "initializing idp"
+    python3 /app/permissions_engine/initialize_idp.py
+    rm /app/initial_setup
 fi
 
 while [ 0 -eq 0 ]


### PR DESCRIPTION
## Tickets
[DIG-1377](https://candig.atlassian.net/browse/DIG-1377)

## Description

Adds the CanDIG user and group during the Dockerfile initialization, and makes sure that the stack is being run as the CanDIG user. This should ideally not change anything, and is only another layer of security (the root user in Docker is actually the same root as on your local filesystem? And we're just relying on Docker isolating the child process enough to prevent it from affecting things outside the container.) This is one PR out of six doing more-or-less the same thing.

[DIG-1377]: https://candig.atlassian.net/browse/DIG-1377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ