### PR TITLE
DIG-1382: Add a path for Opa to verify service tokens

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,9 @@ if [[ -f "/app/initial_setup" ]]; then
 
     sed -i s/OPA_ROOT_TOKEN/$OPA_ROOT_TOKEN/ /app/permissions_engine/authz.rego
 
+    sed -i s/VAULT_URL/$VAULT_URL/ /app/permissions_engine/authz.rego
+    sed -i s/VAULT_URL/$VAULT_URL/ /app/permissions_engine/service.rego
+
     echo "initializing stores"
     python3 /app/initialize_vault_store.py
     if [[ $? -eq 0 ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,8 +13,8 @@ if [[ -f "/app/initial_setup" ]]; then
 
     sed -i s/OPA_ROOT_TOKEN/$OPA_ROOT_TOKEN/ /app/permissions_engine/authz.rego
 
-    sed -i s/VAULT_URL/$VAULT_URL/ /app/permissions_engine/authz.rego
-    sed -i s/VAULT_URL/$VAULT_URL/ /app/permissions_engine/service.rego
+    sed -i s@VAULT_URL@$VAULT_URL@ /app/permissions_engine/authz.rego
+    sed -i s@VAULT_URL@$VAULT_URL@ /app/permissions_engine/service.rego
 
     echo "initializing stores"
     python3 /app/initialize_vault_store.py

--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -55,7 +55,7 @@ allow {
 }
 
 import data.store_token.token as token
-keys = http.send({"method": "get", "url": "http://vault:8200/v1/opa/data", "headers": {"X-Vault-Token": token}}).body.data.keys
+keys = http.send({"method": "get", "url": "VAULT_URL/v1/opa/data", "headers": {"X-Vault-Token": token}}).body.data.keys
 
 decode_verify_token_output[issuer] := output {
     some i

--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -70,3 +70,9 @@ decode_verify_token_output[issuer] := output {
         }
     )
 }
+
+# Any service should be able to verify that a service is who it says it is:
+allow {
+    input.path == ["v1", "data", "service", "verified"]
+    input.method == "POST"
+}

--- a/permissions_engine/service.rego
+++ b/permissions_engine/service.rego
@@ -1,0 +1,13 @@
+package service
+#
+# Verifies that a service is who it says it is
+#
+
+import data.store_token.token as token
+
+url = concat("/", ["http://vault:8200/v1", input.service, "token", input.token])
+service_token = http.send({"method": "get", "url": url, "headers": {"X-Vault-Token": token}}).body.data.token
+
+verified {
+    service_token == input.token
+}

--- a/permissions_engine/service.rego
+++ b/permissions_engine/service.rego
@@ -5,7 +5,7 @@ package service
 
 import data.store_token.token as token
 
-url = concat("/", ["http://vault:8200/v1", input.service, "token", input.token])
+url = concat("/", ["VAULT_URL/v1", input.service, "token", input.token])
 service_token = http.send({"method": "get", "url": url, "headers": {"X-Vault-Token": token}}).body.data.token
 
 verified {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
 jq
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@daisieh/query-token
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
 jq
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.0.0
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@daisieh/query-token


### PR DESCRIPTION
This is a bit tricky to test alone, but is needed for candigv2-authx changes to enable service token verification. This should be tested as part of https://github.com/CanDIG/CanDIGv2/pull/393.