### PR TITLE
DIG-1520: Site admin is a role defined in Opa, not in jwt

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,8 @@ if [[ -f "/app/initial_setup" ]]; then
 
     sed -i s@VAULT_URL@$VAULT_URL@ /app/permissions_engine/authz.rego
     sed -i s@VAULT_URL@$VAULT_URL@ /app/permissions_engine/service.rego
+    sed -i s@VAULT_URL@$VAULT_URL@ /app/permissions_engine/idp.rego
+    sed -i s@VAULT_URL@$VAULT_URL@ /app/permissions_engine/permissions.rego
 
     echo "initializing stores"
     python3 /app/initialize_vault_store.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,7 @@ OPA_ROOT_TOKEN=$(cat /run/secrets/opa-root-token)
 if [[ -f "/app/initial_setup" ]]; then
     sed -i s/CLIENT_ID/$KEYCLOAK_CLIENT_ID/ /app/permissions_engine/idp.rego && sed -i s/CLIENT_ID/$KEYCLOAK_CLIENT_ID/ /app/permissions_engine/authz.rego
     sed -i s/OPA_SITE_ADMIN_KEY/$OPA_SITE_ADMIN_KEY/ /app/permissions_engine/idp.rego && sed -i s/OPA_SITE_ADMIN_KEY/$OPA_SITE_ADMIN_KEY/ /app/permissions_engine/authz.rego
+    sed -i s/CANDIG_USER_KEY/$CANDIG_USER_KEY/ /app/permissions_engine/idp.rego && sed -i s/CANDIG_USER_KEY/$CANDIG_USER_KEY/ /app/permissions_engine/authz.rego
 
     OPA_SERVICE_TOKEN=$(cat /run/secrets/opa-service-token)
     sed -i s/OPA_SERVICE_TOKEN/$OPA_SERVICE_TOKEN/ /app/permissions_engine/authz.rego

--- a/initialize_vault_store.py
+++ b/initialize_vault_store.py
@@ -31,6 +31,13 @@ try:
         if status_code != 200:
             sys.exit(3)
         results.append(response)
+
+    with open('/app/permissions_engine/roles.json') as f:
+        data = f.read()
+        response, status_code = set_service_store_secret("opa", key="roles", value=data)
+        if status_code != 200:
+            sys.exit(2)
+        results.append(response)
 except Exception as e:
     print(str(e))
     sys.exit(4)

--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -53,10 +53,10 @@ identity_rights[right] {             # Right is in the identity_rights set if...
 allow {
     decode_verify_token_output[_][2].realm_access.roles[_] == "OPA_SITE_ADMIN_KEY"
 }
+import data.store_token.token as vault_token
 
-import data.store_token.token as token
-keys = http.send({"method": "get", "url": "VAULT_URL/v1/opa/data", "headers": {"X-Vault-Token": token}}).body.data.keys
 
+keys = http.send({"method": "get", "url": "VAULT_URL/v1/opa/data", "headers": {"X-Vault-Token": vault_token}}).body.data.keys
 decode_verify_token_output[issuer] := output {
     some i
     issuer := keys[i].iss

--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -55,10 +55,10 @@ import data.store_token.token as vault_token
 import future.keywords.in
 
 roles = http.send({"method": "get", "url": "VAULT_URL/v1/opa/roles", "headers": {"X-Vault-Token": vault_token}}).body.data.roles
-user := decode_verify_token_output[_][2].CANDIG_USER_KEY        # get user key from the token payload
+user_key := decode_verify_token_output[_][2].CANDIG_USER_KEY        # get user key from the token payload
 
 allow {
-    user in roles.site_admin
+    user_key in roles.site_admin
 }
 
 keys = http.send({"method": "get", "url": "VAULT_URL/v1/opa/data", "headers": {"X-Vault-Token": vault_token}}).body.data.keys

--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -49,12 +49,17 @@ identity_rights[right] {             # Right is in the identity_rights set if...
     right := rights[role]            # Role has rights defined.
 }
 
-# If token payload has OPA_SITE_ADMIN_KEY in it, allow always
-allow {
-    decode_verify_token_output[_][2].realm_access.roles[_] == "OPA_SITE_ADMIN_KEY"
-}
 import data.store_token.token as vault_token
 
+# If user is site_admin, allow always
+import future.keywords.in
+
+roles = http.send({"method": "get", "url": "VAULT_URL/v1/opa/roles", "headers": {"X-Vault-Token": vault_token}}).body.data.roles
+user := decode_verify_token_output[_][2].CANDIG_USER_KEY        # get user key from the token payload
+
+allow {
+    user in roles.site_admin
+}
 
 keys = http.send({"method": "get", "url": "VAULT_URL/v1/opa/data", "headers": {"X-Vault-Token": vault_token}}).body.data.keys
 decode_verify_token_output[issuer] := output {

--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -6,7 +6,7 @@ package idp
 #
 
 import data.store_token.token as token
-keys = http.send({"method": "get", "url": "http://vault:8200/v1/opa/data", "headers": {"X-Vault-Token": token}}).body.data.keys
+keys = http.send({"method": "get", "url": "VAULT_URL/v1/opa/data", "headers": {"X-Vault-Token": token}}).body.data.keys
 
 decode_verify_token_output[issuer] := output {
     some i
@@ -28,6 +28,8 @@ decode_verify_token_output[issuer] := output {
 valid_token = true {
     decode_verify_token_output[_][0]
 }
+
+user := decode_verify_token_output[_][2].CANDIG_USER_KEY        # get user key from the token payload
 
 #
 # Check trusted_researcher in the token payload

--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -39,10 +39,13 @@ trusted_researcher = true {
 }
 
 #
-# Check OPA_SITE_ADMIN_KEY in the token payload
+# This user is a site admin if they have the site_admin role
 #
-OPA_SITE_ADMIN_KEY = true {
-    decode_verify_token_output[_][2].realm_access.roles[_] == "OPA_SITE_ADMIN_KEY"
+import future.keywords.in
+
+roles = http.send({"method": "get", "url": "VAULT_URL/v1/opa/roles", "headers": {"X-Vault-Token": token}}).body.data.roles
+site_admin = true {
+    user in roles.site_admin
 }
 
 email := decode_verify_token_output[_][2].email        # get email from the token payload

--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -29,7 +29,7 @@ valid_token = true {
     decode_verify_token_output[_][0]
 }
 
-user := decode_verify_token_output[_][2].CANDIG_USER_KEY        # get user key from the token payload
+user_key := decode_verify_token_output[_][2].CANDIG_USER_KEY        # get user key from the token payload
 
 #
 # Check trusted_researcher in the token payload
@@ -45,7 +45,5 @@ import future.keywords.in
 
 roles = http.send({"method": "get", "url": "VAULT_URL/v1/opa/roles", "headers": {"X-Vault-Token": token}}).body.data.roles
 site_admin = true {
-    user in roles.site_admin
+    user_key in roles.site_admin
 }
-
-email := decode_verify_token_output[_][2].email        # get email from the token payload

--- a/permissions_engine/permissions.rego
+++ b/permissions_engine/permissions.rego
@@ -23,7 +23,7 @@ post_input_paths = paths.post
 #
 import data.idp.valid_token
 import data.idp.trusted_researcher
-import data.idp.email
+import data.idp.user_key
 
 #
 # is registered access allowed?
@@ -43,7 +43,7 @@ registered_allowed = access.registered_datasets {
 
 default controlled_allowed = []
 
-controlled_allowed = access.controlled_access_list[email]{
+controlled_allowed = access.controlled_access_list[user_key]{
     valid_token                  # extant, valid token
 }
 

--- a/permissions_engine/permissions.rego
+++ b/permissions_engine/permissions.rego
@@ -6,9 +6,9 @@ package permissions
 default datasets = []
 
 import data.store_token.token as token
-access = http.send({"method": "get", "url": "http://vault:8200/v1/opa/access", "headers": {"X-Vault-Token": token}}).body.data.access
+access = http.send({"method": "get", "url": "VAULT_URL/v1/opa/access", "headers": {"X-Vault-Token": token}}).body.data.access
 
-paths = http.send({"method": "get", "url": "http://vault:8200/v1/opa/paths", "headers": {"X-Vault-Token": token}}).body.data.paths
+paths = http.send({"method": "get", "url": "VAULT_URL/v1/opa/paths", "headers": {"X-Vault-Token": token}}).body.data.paths
 
 get_input_paths = paths.get
 post_input_paths = paths.post

--- a/permissions_engine/roles.json
+++ b/permissions_engine/roles.json
@@ -1,0 +1,17 @@
+{
+    "roles": {
+        "site_admin": [
+            "user2@test.ca"
+        ],
+        "data_custodian": [
+        ],
+        "local_team": [
+            "user1@test.ca"
+        ],
+        "mohccn_network": [
+            "user1@test.ca",
+            "user2@test.ca"
+        ]
+    }
+}
+


### PR DESCRIPTION
This starts a role-based system for authz in Opa. Authx functions don't have to change for this, so outside functionality won't have any changes. I did add a new environment variable that will be passed in docker-compose, CANDIG_USER_KEY: this allows the site to specifically define the unique key used by their own IDP's jwts to specify the user (we'll use email by default).

Tested in https://github.com/CanDIG/CanDIGv2/pull/488/.