### PR TITLE
Interpolate default usernames from .env file instead of hardcoding

### DIFF
--- a/defaults/programs.json
+++ b/defaults/programs.json
@@ -1,14 +1,14 @@
 {
     "SYNTHETIC-1": {
         "program_id": "SYNTHETIC-1",
-        "program_curators": ["user1@test.ca"],
-        "team_members": ["user1@test.ca"],
+        "program_curators": ["USER1"],
+        "team_members": ["USER1"],
         "date_created": "2020-01-01"
     },
     "SYNTHETIC-2": {
         "program_id": "SYNTHETIC-2",
-        "program_curators": ["user2@test.ca"],
-        "team_members": ["user2@test.ca"],
+        "program_curators": ["USER2"],
+        "team_members": ["USER2"],
         "date_created": "2020-03-01"
     }
 }

--- a/defaults/roles.json
+++ b/defaults/roles.json
@@ -1,16 +1,16 @@
 {
     "roles": {
         "site_admin": [
-            "user2@test.ca"
+            "SITE_ADMIN_USER"
         ],
         "site_curator": [
         ],
         "local_team": [
-            "user1@test.ca"
+            "USER1"
         ],
         "mohccn_network": [
-            "user1@test.ca",
-            "user2@test.ca"
+            "USER1",
+            "USER2"
         ]
     }
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,17 +3,28 @@
 set -Euo pipefail
 
 OPA_ROOT_TOKEN=$(cat /run/secrets/opa-root-token)
+SITE_ADMIN_USER=$(cat /run/secrets/site_admin_name)
+USER1=$(cat /run/secrets/user1_name)
+USER2=$(cat /run/secrets/user2_name)
 
 if [[ -f "/app/initial_setup" ]]; then
+    # set up our default values
     sed -i s/CLIENT_ID/$KEYCLOAK_CLIENT_ID/ /app/permissions_engine/idp.rego && sed -i s/CLIENT_ID/$KEYCLOAK_CLIENT_ID/ /app/permissions_engine/authz.rego
-    sed -i s/OPA_SITE_ADMIN_KEY/$OPA_SITE_ADMIN_KEY/ /app/permissions_engine/idp.rego && sed -i s/OPA_SITE_ADMIN_KEY/$OPA_SITE_ADMIN_KEY/ /app/permissions_engine/authz.rego
     sed -i s/CANDIG_USER_KEY/$CANDIG_USER_KEY/ /app/permissions_engine/idp.rego && sed -i s/CANDIG_USER_KEY/$CANDIG_USER_KEY/ /app/permissions_engine/authz.rego
+
+    # set up default users in default jsons:
+    sed -i s/SITE_ADMIN_USER/$SITE_ADMIN_USER/ /app/defaults/roles.json
+    sed -i s/USER1/$USER1/ /app/defaults/roles.json
+    sed -i s/USER2/$USER2/ /app/defaults/roles.json
+    sed -i s/SITE_ADMIN_USER/$SITE_ADMIN_USER/ /app/defaults/programs.json
+    sed -i s/USER1/$USER1/ /app/defaults/programs.json
+    sed -i s/USER2/$USER2/ /app/defaults/programs.json
 
     OPA_SERVICE_TOKEN=$(cat /run/secrets/opa-service-token)
     sed -i s/OPA_SERVICE_TOKEN/$OPA_SERVICE_TOKEN/ /app/permissions_engine/authz.rego
-
     sed -i s/OPA_ROOT_TOKEN/$OPA_ROOT_TOKEN/ /app/permissions_engine/authz.rego
 
+    # set up vault URL everywhere
     sed -i s@VAULT_URL@$VAULT_URL@ /app/permissions_engine/authz.rego
     sed -i s@VAULT_URL@$VAULT_URL@ /app/permissions_engine/service.rego
     sed -i s@VAULT_URL@$VAULT_URL@ /app/permissions_engine/idp.rego

--- a/healthcheck.py
+++ b/healthcheck.py
@@ -1,51 +1,26 @@
-import json
 import os
-import re
 import sys
-import uuid
-from http import HTTPStatus
-from pathlib import Path
-import datetime
 import requests
 
-keycloak_url = os.environ.get('KEYCLOAK_PUBLIC_URL')
+opa_url = os.environ.get('OPA_URL')
 
-# Read Docker secrets
-with open("/run/secrets/client_secret") as f:
-    client_secret = f.read().strip()
-
-with open("/run/secrets/password") as f:
-    password = f.read().strip()
-
-def get_token(username=None, password=None, client_id=None, client_secret=None):
-    payload = {
-        "client_id": client_id,
-        "client_secret": client_secret,
-        "grant_type": "password",
-        "username": username,
-        "password": password,
-        "scope": "openid",
-    }
-    response = requests.post(
-        f"{keycloak_url}/auth/realms/candig/protocol/openid-connect/token",
-        data=payload,
-    )
-    if response.status_code == 200:
-        return response.json()["access_token"]
 
 def perform_healthcheck():
-    auth_token = get_token(username="user2", password=password, client_id="local_candig", client_secret=client_secret)
-    headers = {"Authorization": f"Bearer {auth_token}"}
-    url = os.environ.get('OPA_URL')
-
     try:
-        response = requests.get(url, headers=headers)
+        body = {
+            "input": {
+                "service": "opa",
+                "token": "token" # this isn't important; even if it's wrong, it returns 200
+            }
+        }
+        response = requests.post(f"{opa_url}/v1/data/service/verified", json=body)
         response.raise_for_status()
         print("Health check passed!")
         return True
     except requests.exceptions.RequestException as e:
         print(f"Health check failed: {e}")
         return False
+
 
 if __name__ == "__main__":
     health_status = perform_healthcheck()


### PR DESCRIPTION
This matches https://github.com/CanDIG/CanDIGv2/pull/527. Based on the passed-in secrets that specify the test user names, entrypoint interpolates them into the default json files. In addition, I updated the healthcheck to use something internal to Opa and not keycloak.