### PR TITLE
DIG-898: allow service_token to view user_key

### DIFF
--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -16,6 +16,9 @@ rights = {
     "site_admin": {
         "path": ["v1", "data", "permissions", "site_admin"]
     },
+    "user_id": {
+        "path": ["v1", "data", "idp", "user_key"]
+    },
     "tokenControlledAccessREMS": {
         "path": ["v1", "data", "ga4ghPassport", "tokenControlledAccessREMS"]
     }
@@ -29,7 +32,7 @@ tokens = {
         "roles": ["admin"]
     },
     service_token : {
-        "roles": ["datasets", "allowed", "site_admin", "tokenControlledAccessREMS"]
+        "roles": ["datasets", "allowed", "site_admin", "user_id", "tokenControlledAccessREMS"]
     }
 }
 


### PR DESCRIPTION
Specifically allow the service token to view the decoded user key.

To test: clean/docker-volumes/build/compose opa, then try calling 
```
curl -X "POST" "http://candig.docker.internal:8181/v1/data/idp" \
     -H 'Content-Type: application/json' \
     -H 'Accept: application/json' \
     -H 'X-Opa: opa-service-token' \
     -d $'{
  "input": {
    "token": "user token"
  }
}'
```
You should get the value of the user key (the email) as a response.
