### PR TITLE
If vault stores already exist, don't wipe them out

### DIFF
--- a/initialize_vault_store.py
+++ b/initialize_vault_store.py
@@ -14,7 +14,7 @@ try:
             response = add_provider_to_opa(token, os.getenv("KEYCLOAK_REALM_URL"))
             results.append(response)
         except Exception as e:
-            print(str(e))
+            raise Exception(f"failed to save idp keys: {str(e)} {status_code}")
             sys.exit(1)
 
     response, status_code = get_service_store_secret("opa", key="paths")
@@ -23,7 +23,7 @@ try:
             data = f.read()
             response, status_code = set_service_store_secret("opa", key="paths", value=data)
             if status_code != 200:
-                sys.exit(3)
+                raise Exception(f"failed to save paths: {str(e)} {status_code}")
             results.append(response)
 
     response, status_code = get_service_store_secret("opa", key="site_roles")
@@ -32,7 +32,7 @@ try:
             data = f.read()
             response, status_code = set_service_store_secret("opa", key="site_roles", value=data)
             if status_code != 200:
-                sys.exit(2)
+                raise Exception(f"failed to save site roles: {str(e)} {status_code}")
             results.append(response)
 
     current_programs, status_code = list_programs_in_opa()
@@ -44,7 +44,7 @@ try:
             if programs[program] not in current_programs:
                 response, status_code = add_program_to_opa(programs[program])
                 if status_code != 200:
-                    sys.exit(2)
+                    raise Exception(f"failed to save program authz: {str(e)} {status_code}")
                 results.append(response)
 except Exception as e:
     print(str(e))

--- a/initialize_vault_store.py
+++ b/initialize_vault_store.py
@@ -1,6 +1,6 @@
 import json
 import os
-from authx.auth import get_service_store_secret, set_service_store_secret, add_provider_to_opa, add_program_to_opa
+from authx.auth import get_service_store_secret, set_service_store_secret, add_provider_to_opa, add_program_to_opa, list_programs_in_opa
 import sys
 
 ## Initializes Vault's opa service store with the information for our IDP and the data in site_roles.json, paths.json, programs.json
@@ -11,34 +11,41 @@ try:
     with open('/app/bearer.txt') as f:
         try:
             token = f.read().strip()
-            response, status_code = set_service_store_secret("opa", key="data", value=json.dumps({"keys":[]}))
             response = add_provider_to_opa(token, os.getenv("KEYCLOAK_REALM_URL"))
             results.append(response)
         except Exception as e:
             print(str(e))
             sys.exit(1)
 
-    with open('/app/defaults/paths.json') as f:
-        data = f.read()
-        response, status_code = set_service_store_secret("opa", key="paths", value=data)
-        if status_code != 200:
-            sys.exit(3)
-        results.append(response)
+    response, status_code = get_service_store_secret("opa", key="paths")
+    if status_code != 200:
+        with open('/app/defaults/paths.json') as f:
+            data = f.read()
+            response, status_code = set_service_store_secret("opa", key="paths", value=data)
+            if status_code != 200:
+                sys.exit(3)
+            results.append(response)
 
-    with open('/app/defaults/site_roles.json') as f:
-        data = f.read()
-        response, status_code = set_service_store_secret("opa", key="site_roles", value=data)
-        if status_code != 200:
-            sys.exit(2)
-        results.append(response)
-
-    with open('/app/defaults/programs.json') as f:
-        programs = json.load(f)
-        for program in programs:
-            response, status_code = add_program_to_opa(programs[program])
+    response, status_code = get_service_store_secret("opa", key="site_roles")
+    if status_code != 200:
+        with open('/app/defaults/site_roles.json') as f:
+            data = f.read()
+            response, status_code = set_service_store_secret("opa", key="site_roles", value=data)
             if status_code != 200:
                 sys.exit(2)
             results.append(response)
+
+    current_programs, status_code = list_programs_in_opa()
+    if status_code != 200:
+        current_programs = []
+    with open('/app/defaults/programs.json') as f:
+        programs = json.load(f)
+        for program in programs:
+            if programs[program] not in current_programs:
+                response, status_code = add_program_to_opa(programs[program])
+                if status_code != 200:
+                    sys.exit(2)
+                results.append(response)
 except Exception as e:
     print(str(e))
     sys.exit(4)


### PR DESCRIPTION
If we need to rebuild/recompose opa, we shouldn't wipe out any existing vault secrets.