### PR TITLE
DIG-1189: Authz user can view datasets

### DIFF
--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -74,3 +74,11 @@ allow {
 allow {
     data.permissions.site_admin == true
 }
+
+# As long as the user is authorized, should be able to get their own datasets
+allow {
+    input.path == ["v1", "data", "permissions", "datasets"]
+    input.method == "POST"
+    data.permissions.valid_token == true
+    input.body.input.token == input.identity
+}

--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -69,3 +69,8 @@ allow {
     input.path == ["v1", "data", "service", "service-info"]
     input.method == "GET"
 }
+
+# Site admin should be able to see anything
+allow {
+    data.permissions.site_admin == true
+}

--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -82,3 +82,11 @@ allow {
     data.permissions.valid_token == true
     input.body.input.token == input.identity
 }
+
+# As long as the user is authorized, should be able to see if they're allowed to view something
+allow {
+    input.path == ["v1", "data", "permissions", "allowed"]
+    input.method == "POST"
+    data.permissions.valid_token == true
+    input.body.input.token == input.identity
+}


### PR DESCRIPTION
If the user token is the same in both the Bearer token and in the body of the request, and that token is valid, you should be able to get the user's authorized datasets.

```
## opa datasets
curl -X "POST" "http://candig.docker.internal:5080/policy/v1/data/permissions/datasets" \
     -H 'Authorization: Bearer <user token>' \
     -H 'Content-Type: application/json' \
     -H 'Accept: application/json' \
     -d $'{
  "input": {
    "token": "<same user token>",
    "body": {
      "path": "/v2/authorized/sample_registrations/",
      "method": "GET"
    }
  }
}'
```
should give you the user's authorized datasets. If you try to use different tokens, e.g. Bearer token is for user2, and the requested input token is for site_admin, it should fail.