### PR TITLE
DIG-1652: Remove use of OPA_SERVICE_TOKEN and OPA_ROOT_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Interactions with Vault are handled by [vault.rego](permissions_engine/vault.reg
 
 Authorization to endpoints in the OPA service itself is defined in [authz.rego](permissions_engine/authz.rego).
 
-* Token-based auth: There are two api tokens defined: the root token allows any path to be accessed, while the service token only allows the `permissions/datasets` and `permissions/allowed` endpoints to be viewed.
-
 * Role-based auth: Roles for the site are defined in the format given in [site_roles.json](defaults/site_roles.json). if the User is defined as a site admin, they are allowed to view any endpoint. Other site-based roles can be similarly defined.
 
 * Endpoint-based auth: Any service can use the `/service/verified` endpoint. Other specific endpoints can be similarly allowed.
 
-* Program-based and user-based authorizations are defined at the `permissions` path: For a given User and the method of accessing a service (method, path), the `/permissions/datasets` endpoint returns the list of programs that user is allowed to access for that method/path, while the `/permissions/allowed` endpoint returns True if either the user is a site admin or the user is allowed to access that method/path. The following two types of authorizations are available:
+* An authenticated and authorized user is allowed to find out their own user ID, the key of which is defined system-wide in the .env file as CANDIG_USER_KEY. By default, this is the user's email address. This is the user ID by which user-based and program-based authorizations are keyed.
+
+* Program-based and user-based authorizations are defined at the `permissions` path: A User can access these Opa endpoints to introspect their own authorizations. For a given method of accessing a service (method, path), the `/permissions/datasets` endpoint returns the list of programs that the User is allowed to access for that method/path, while the `/permissions/allowed` endpoint returns True if either the User is a site admin or the User is allowed to access that method/path. The following two types of authorizations are available:
 
   * Authorizations for roles in particular programs: users defined as team_members for a program are allowed to access the read paths specified in [paths.json](defaults/paths.json), while users defined as program_curators are allowed to access the curate and delete paths. Note: read and curate paths are separately allowed: if a user should be allowed to both read and curate, they should be in both the team_members and program_curators groups. Program authorizations can be created, edited, and deleted through the ingest microservice. Default test examples can be found in [programs.json](defaults/programs.json).
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,6 @@
 
 set -Euo pipefail
 
-OPA_ROOT_TOKEN=$(cat /run/secrets/opa-root-token)
-OPA_SERVICE_TOKEN=$(cat /run/secrets/opa-service-token)
 
 if [[ -f "/app/initial_setup" ]]; then
     # set up our default values
@@ -17,9 +15,8 @@ if [[ -f "/app/initial_setup" ]]; then
     sed -i s/USER1/$USER1/ /app/defaults/programs.json
     sed -i s/USER2/$USER2/ /app/defaults/programs.json
 
-    sed -i s/OPA_SERVICE_TOKEN/$OPA_SERVICE_TOKEN/ /app/permissions_engine/authz.rego
-    sed -i s/OPA_ROOT_TOKEN/$OPA_ROOT_TOKEN/ /app/permissions_engine/authz.rego
-
+    token=$(dd if=/dev/urandom bs=1 count=16 2>/dev/null | base64 | tr -d '\n\r+' | sed s/[^A-Za-z0-9]//g)
+    echo { \"opa_secret\": \"$token\" } > /app/permissions_engine/opa_secret.json
     # set up vault URL
     sed -i s@VAULT_URL@$VAULT_URL@ /app/permissions_engine/vault.rego
 

--- a/get_vault_store_token.py
+++ b/get_vault_store_token.py
@@ -7,11 +7,11 @@ import requests
 
 # get the token for the opa store
 try:
-    with open("/run/secrets/opa-root-token") as f:
-        OPA_ROOT_TOKEN = f.read().strip()
+    with open("/app/permissions_engine/opa_secret.json") as f:
+        opa_json = json.load(f)
         opa_token = get_vault_token_for_service("opa")
         headers = {
-            "X-Opa": OPA_ROOT_TOKEN,
+            "X-Opa": opa_json["opa_secret"],
             "Content-Type": "application/json; charset=utf-8"
         }
         payload = f"{{\"token\": \"{opa_token}\"}}"

--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -64,6 +64,13 @@ allow {
     input.method == "POST"
 }
 
+# Opa should be able to store its vault token
+allow {
+    input.path == ["v1", "data", "store_token"]
+    input.method == "PUT"
+    input.headers["X-Opa"][_] == data.opa_secret
+}
+
 # Service-info path for healthcheck
 allow {
     input.path == ["v1", "data", "service", "service-info"]

--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -3,59 +3,8 @@ package system.authz
 # this defines authentication to have access to opa at all
 # from: https://www.openpolicyagent.org/docs/v0.22.0/security/#token-based-authentication-example
 
-rights = {
-    "admin": {
-        "path": "*"
-    },
-    "datasets": {
-        "path": ["v1", "data", "permissions", "datasets"]
-    },
-    "allowed": {
-        "path": ["v1", "data", "permissions", "allowed"]
-    },
-    "site_admin": {
-        "path": ["v1", "data", "permissions", "site_admin"]
-    },
-    "user_id": {
-        "path": ["v1", "data", "idp", "user_key"]
-    },
-    "tokenControlledAccessREMS": {
-        "path": ["v1", "data", "ga4ghPassport", "tokenControlledAccessREMS"]
-    }
-}
-
-root_token := "OPA_ROOT_TOKEN"
-service_token := "OPA_SERVICE_TOKEN"
-
-tokens = {
-    root_token : {
-        "roles": ["admin"]
-    },
-    service_token : {
-        "roles": ["datasets", "allowed", "site_admin", "user_id", "tokenControlledAccessREMS"]
-    }
-}
-
 default allow = false               # Reject requests by default.
 
-allow {                             # Allow request if...
-    some right
-    identity_rights[right]          # Rights for identity exist, and...
-    right.path == "*"               # Right.path is '*'.
-}
-
-allow {                             # Allow request if...
-    some right
-    identity_rights[right]          # Rights for identity exist, and...
-    right.path == input.path        # Right.path matches input.path.
-}
-
-x_opa := input.headers["X-Opa"][_]
-
-identity_rights[right] {             # Right is in the identity_rights set if...
-    token := tokens[x_opa]  # Token exists for identity, and...
-    role := token.roles[_]           # Token has a role, and...
-    right := rights[role]            # Role has rights defined.
 }
 
 # Any service should be able to verify that a service is who it says it is:

--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -3,8 +3,12 @@ package system.authz
 # this defines authentication to have access to opa at all
 # from: https://www.openpolicyagent.org/docs/v0.22.0/security/#token-based-authentication-example
 
-default allow = false               # Reject requests by default.
+# Reject requests by default
+default allow = false
 
+# Site admin should be able to see anything
+allow {
+    data.permissions.site_admin == true
 }
 
 # Any service should be able to verify that a service is who it says it is:
@@ -24,11 +28,6 @@ allow {
 allow {
     input.path == ["v1", "data", "service", "service-info"]
     input.method == "GET"
-}
-
-# Site admin should be able to see anything
-allow {
-    data.permissions.site_admin == true
 }
 
 # The authx library uses these paths:

--- a/permissions_engine/authz.rego
+++ b/permissions_engine/authz.rego
@@ -31,17 +31,18 @@ allow {
     data.permissions.site_admin == true
 }
 
-# As long as the user is authorized, should be able to get their own datasets
-allow {
-    input.path == ["v1", "data", "permissions", "datasets"]
-    input.method == "POST"
-    data.permissions.valid_token == true
-    input.body.input.token == input.identity
+# The authx library uses these paths:
+authx_paths = {
+    "datasets": ["v1", "data", "permissions", "datasets"],
+    "allowed": ["v1", "data", "permissions", "allowed"],
+    "site_admin": ["v1", "data", "permissions", "site_admin"],
+    "user_id": ["v1", "data", "idp", "user_key"]
 }
 
-# As long as the user is authorized, should be able to see if they're allowed to view something
+# An authorized user has a valid token (and passes in that same token for both bearer and body)
+# Authz users can access the authx paths
 allow {
-    input.path == ["v1", "data", "permissions", "allowed"]
+    input.path == authx_paths[_]
     input.method == "POST"
     data.permissions.valid_token == true
     input.body.input.token == input.identity


### PR DESCRIPTION
Instead of using special tokens, we split up the use cases in these three ways:

1. For the opa-runner container, to make sure that it is the only one that can access/store its own vault token, we create a secret for its own use on initialization, and make sure that the token passed in with calls to `v1/data/store_token` is the same as that internal secret.
2. For site admins, we can check that the token belongs to a user listed as having the site_role `admin`. Those users can access any of Opa's paths.
3. For the authx library (and other microservices), authenticated users can access information about their own user's authorizations. These include the authorized datasets, whether or not they're a site admin, and what their user ID is. These should be available as long as the bearer token matches the body token and is verified with one of Opa's known IdPs.

All previous tests that required passing in OPA_ROOT_TOKEN or OPA_SERVICE_TOKEN for the `X-Opa` header should now work correctly without that header, since they were one of the above use cases. Run `make clean-opa; make docker-volumes; make build-opa; make compose-opa` and then run integration tests. They should pass as before.