### PR TITLE
Opa should always renew its IDP information

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,13 +24,15 @@ if [[ -f "/app/initial_setup" ]]; then
     python3 /app/initialize_vault_store.py
     if [[ $? -eq 0 ]]; then
         rm /app/initial_setup
-        rm /app/bearer.txt
         echo "setup complete"
     else
         echo "!!!!!! INITIALIZATION FAILED, TRY AGAIN !!!!!!"
     fi
 fi
 
+# make sure that our idp is still set correctly (maybe keycloak was reinitialized)
+python3 get_vault_store_token.py
+python3 /app/initialize_idp.py
 
 while [ 0 -eq 0 ]
 do

--- a/initialize_idp.py
+++ b/initialize_idp.py
@@ -1,0 +1,23 @@
+import json
+import os
+from authx.auth import add_provider_to_opa, get_user_id
+import sys
+
+## Updates Vault's opa service store with the information for our IDP
+
+token = None
+try:
+    if os.path.isfile('/app/bearer.txt'):
+        with open('/app/bearer.txt') as f:
+            token = f.read().strip()
+    if token is not None:
+        response = add_provider_to_opa(token, os.getenv("KEYCLOAK_REALM_URL"))
+        os.remove('/app/bearer.txt')
+        if get_user_id(None, token=token) is None:
+            print("IDP is incorrect: verify that Keycloak is set up and clean/build/compose opa again")
+            sys.exit(2)
+except Exception as e:
+    raise Exception(f"failed to save idp keys: {str(e)} {status_code}")
+    sys.exit(1)
+
+sys.exit(0)

--- a/initialize_idp.py
+++ b/initialize_idp.py
@@ -11,6 +11,7 @@ try:
         with open('/app/bearer.txt') as f:
             token = f.read().strip()
     if token is not None:
+        print("Updating our IDP with a new bearer token")
         response = add_provider_to_opa(token, os.getenv("KEYCLOAK_REALM_URL"))
         os.remove('/app/bearer.txt')
         if get_user_id(None, token=token) is None:

--- a/initialize_vault_store.py
+++ b/initialize_vault_store.py
@@ -1,29 +1,20 @@
 import json
 import os
-from authx.auth import get_service_store_secret, set_service_store_secret, add_provider_to_opa, add_program_to_opa, list_programs_in_opa
+from authx.auth import get_service_store_secret, set_service_store_secret, add_program_to_opa, list_programs_in_opa
 import sys
 
-## Initializes Vault's opa service store with the information for our IDP and the data in site_roles.json, paths.json, programs.json
+## Initializes Vault's opa service store with the data in site_roles.json, paths.json, programs.json
 
 results = []
 
 try:
-    with open('/app/bearer.txt') as f:
-        try:
-            token = f.read().strip()
-            response = add_provider_to_opa(token, os.getenv("KEYCLOAK_REALM_URL"))
-            results.append(response)
-        except Exception as e:
-            raise Exception(f"failed to save idp keys: {str(e)} {status_code}")
-            sys.exit(1)
-
     response, status_code = get_service_store_secret("opa", key="paths")
     if status_code != 200:
         with open('/app/defaults/paths.json') as f:
             data = f.read()
             response, status_code = set_service_store_secret("opa", key="paths", value=data)
             if status_code != 200:
-                raise Exception(f"failed to save paths: {str(e)} {status_code}")
+                raise Exception(f"failed to save paths: {response} {status_code}")
             results.append(response)
 
     response, status_code = get_service_store_secret("opa", key="site_roles")
@@ -32,7 +23,7 @@ try:
             data = f.read()
             response, status_code = set_service_store_secret("opa", key="site_roles", value=data)
             if status_code != 200:
-                raise Exception(f"failed to save site roles: {str(e)} {status_code}")
+                raise Exception(f"failed to save site roles: {response} {status_code}")
             results.append(response)
 
     current_programs, status_code = list_programs_in_opa()
@@ -44,7 +35,7 @@ try:
             if programs[program] not in current_programs:
                 response, status_code = add_program_to_opa(programs[program])
                 if status_code != 200:
-                    raise Exception(f"failed to save program authz: {str(e)} {status_code}")
+                    raise Exception(f"failed to save program authz: {response} {status_code}")
                 results.append(response)
 except Exception as e:
     print(str(e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 jq
 pytest==7.2.0
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@daisieh/renew-idp
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests
 jq
 pytest==7.2.0
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.4.2
-
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@daisieh/renew-idp


### PR DESCRIPTION
In case the underlying Keycloak instance changes and therefore our saved IdP keys are invalidated, we need to make sure that we can update the value in Opa's vault store.

The authx change allows for us to call authx.auth.add_provider_to_opa again with our bearer token and update the value in vault any time the file `/app/bearer.txt` is found on startup.

To test: get a site admin token and save it to a file test.txt. Then run
```
docker cp test.txt candigv2_opa-runner_1:/app/bearer.txt
docker restart candigv2_opa-runner_1
```
You should see a log message `Updating our IDP with a new bearer token` at the time you did that. You should NOT see a message following that says `IDP is incorrect: verify that Keycloak is set up and clean/build/compose opa again`.