### PR TITLE
DIG-1705: implement site-level curator role

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ Interactions with Vault are handled by [vault.rego](permissions_engine/vault.reg
 
 Authorization to endpoints in the OPA service itself is defined in [authz.rego](permissions_engine/authz.rego).
 
-* Role-based auth: Roles for the site are defined in the format given in [site_roles.json](defaults/site_roles.json). if the User is defined as a site admin, they are allowed to view any endpoint. Other site-based roles can be similarly defined.
+* Role-based auth: Roles for the site are defined in the format given in [site_roles.json](defaults/site_roles.json).
+  * If the User is defined as a site admin, they are allowed to access any endpoint.
+  * If the User is defined as a site curator, they are allowed to use any of the curate method/path combinations defined in [paths.json](defaults/paths.json) for all programs known to the system.
+  * Other site-based roles can be similarly defined.
 
 * Endpoint-based auth: Any service can use the `/service/verified` endpoint. Other specific endpoints can be similarly allowed.
 

--- a/defaults/site_roles.json
+++ b/defaults/site_roles.json
@@ -4,6 +4,7 @@
             "SITE_ADMIN_USER"
         ],
         "curator": [
+            "USER2"
         ],
         "local_team": [
             "USER1"

--- a/permissions_engine/permissions.rego
+++ b/permissions_engine/permissions.rego
@@ -101,7 +101,32 @@ else := readable_programs
     regex.match(paths.read.post[_], input.body.path) == true
 }
 
-# if user is a program_curator, they can access programs that allow curate access for this method, path
+# if user is a site curator, they can access all programs that allow curate access for this method, path
+else := all_programs
+{
+    valid_token
+    user_key in site_roles.curator
+    input.body.method = "GET"
+    regex.match(paths.curate.get[_], input.body.path) == true
+}
+
+else := all_programs
+{
+    valid_token
+    user_key in site_roles.curator
+    input.body.method = "POST"
+    regex.match(paths.curate.post[_], input.body.path) == true
+}
+
+else := all_programs
+{
+    valid_token
+    user_key in site_roles.curator
+    input.body.method = "DELETE"
+    regex.match(paths.curate.delete[_], input.body.path) == true
+}
+
+# if user is a program_curator, they can access programs that allow curate access for them for this method, path
 else := curateable_programs
 {
     valid_token

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
 jq
 pytest==7.2.0
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.4.4
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.4.5
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.0

--- a/tests/test_opa_permissions.py
+++ b/tests/test_opa_permissions.py
@@ -23,7 +23,9 @@ def site_roles():
       "admin": [
         "site_admin@test.ca"
       ],
-      "curator": [],
+      "curator": [
+        "user2@test.ca"
+      ],
       "local_team": [
         "user1@test.ca"
       ],
@@ -280,6 +282,17 @@ def get_curation_allowed():
                 "body": {
                   "path": "/ga4gh/drs/v1/cohorts/",
                   "method": "POST"
+                }
+            },
+            True
+        ),
+        ( # user2 can curate the datasets it's not a curator of because they're a site curator
+            "user2",
+            {
+                "body": {
+                  "path": "/ga4gh/drs/v1/cohorts/",
+                  "method": "POST",
+                  "program": "SYNTHETIC-1"
                 }
             },
             True


### PR DESCRIPTION
Add clauses in permissions.rego to allow site curators to access curate method/paths for all programs.

There is a test to verify this in the pytest suite.