### PR TITLE
DIG-1506: Make the decision logic in Opa more transparent

### DIFF
--- a/permissions_engine/calculate.rego
+++ b/permissions_engine/calculate.rego
@@ -1,0 +1,144 @@
+package calculate
+#
+# This is the set of policy definitions for the permissions engine.
+#
+
+#
+# Provided:
+# input = {
+#     'token': user token
+#     'method': method requested at data service
+#     'path': path to request at data service
+#     'program': name of program (optional)
+# }
+#
+import data.idp.user_key as user_key
+import future.keywords.in
+
+#
+# This user is a site admin if they have the site_admin role
+#
+import data.vault.site_roles as site_roles
+site_admin = true {
+    user_key in site_roles.admin
+}
+
+#
+# what programs are available to this user?
+#
+
+import data.vault.all_programs as all_programs
+import data.vault.program_auths as program_auths
+import data.vault.user_programs as user_programs
+
+# compile list of programs specifically authorized for the user by DACs and within the authorized time period
+user_readable_programs[p["program_id"]] := output {
+    some p in user_programs
+    time.parse_ns("2006-01-02", p["start_date"]) <= time.now_ns()
+    time.parse_ns("2006-01-02", p["end_date"]) >= time.now_ns()
+    output := p
+}
+
+# compile list of programs that list the user as a team member
+team_readable_programs[p] := output {
+    some p in all_programs
+    user_key in program_auths[p].team_members
+    output := program_auths[p].team_members
+}
+
+# user can read programs that are either team-readable or user-readable
+readable_programs := object.keys(object.union(team_readable_programs, user_readable_programs))
+
+# user can curate programs that list the user as a program curator
+curateable_programs[p] {
+    some p in all_programs
+    user_key in program_auths[p].program_curators
+}
+
+import data.vault.paths as paths
+
+# debugging
+readable_get[p] := output {
+    some p in paths.read.get
+    output := regex.match(p, input.body.path)
+}
+readable_post[p] := output {
+    some p in paths.read.post
+    output := regex.match(p, input.body.path)
+}
+curateable_get[p] := output {
+    some p in paths.curate.get
+    output := regex.match(p, input.body.path)
+}
+curateable_post[p] := output {
+    some p in paths.curate.post
+    output := regex.match(p, input.body.path)
+}
+curateable_delete[p] := output {
+    some p in paths.curate.delete
+    output := regex.match(p, input.body.path)
+}
+
+# which datasets can this user see for this method, path
+default datasets = []
+
+# site admins can see all programs
+datasets := all_programs
+{
+    site_admin
+}
+
+# if user is a team_member, they can access programs that allow read access for this method, path
+else := readable_programs
+{
+    input.body.method = "GET"
+    regex.match(paths.read.get[_], input.body.path) == true
+}
+
+else := readable_programs
+{
+    input.body.method = "POST"
+    regex.match(paths.read.post[_], input.body.path) == true
+}
+
+# if user is a site curator, they can access all programs that allow curate access for this method, path
+else := all_programs
+{
+    user_key in site_roles.curator
+    input.body.method = "GET"
+    regex.match(paths.curate.get[_], input.body.path) == true
+}
+
+else := all_programs
+{
+    user_key in site_roles.curator
+    input.body.method = "POST"
+    regex.match(paths.curate.post[_], input.body.path) == true
+}
+
+else := all_programs
+{
+    user_key in site_roles.curator
+    input.body.method = "DELETE"
+    regex.match(paths.curate.delete[_], input.body.path) == true
+}
+
+# if user is a program_curator, they can access programs that allow curate access for them for this method, path
+else := curateable_programs
+{
+    input.body.method = "GET"
+    regex.match(paths.curate.get[_], input.body.path) == true
+}
+
+else := curateable_programs
+{
+    input.body.method = "POST"
+    regex.match(paths.curate.post[_], input.body.path) == true
+}
+
+else := curateable_programs
+{
+    input.body.method = "DELETE"
+    regex.match(paths.curate.delete[_], input.body.path) == true
+}
+

--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -25,6 +25,23 @@ decode_verify_token(key, token) := output {
     )
 }
 
+decode_token(token) := output {
+    output := io.jwt.decode(token)
+}
+
+decoded_output := output {
+    possible_tokens := ["identity", "token"]
+    output := decode_token(input[possible_tokens[_]])
+}
+
+user_info := decoded_output[1]
+
+#
+# The user's key, as determined by this candig instance
+#
+user_key := user_info.CANDIG_USER_KEY
+
+
 #
 # If either input.identity or input.token are valid against an issuer, decode and verify
 #
@@ -49,11 +66,6 @@ token_issuer := i {
 valid_token = true {
     decode_verify_token_output[_][0]
 }
-
-#
-# The user's key, as determined by this candig instance
-#
-user_key := decode_verify_token_output[token_issuer][2].CANDIG_USER_KEY
 
 #
 # Check trusted_researcher in the token payload

--- a/permissions_engine/mask.rego
+++ b/permissions_engine/mask.rego
@@ -1,0 +1,6 @@
+package system.log
+
+import rego.v1
+
+# To mask certain fields unconditionally, omit the rule body.
+mask contains "/input/token"

--- a/permissions_engine/permissions.rego
+++ b/permissions_engine/permissions.rego
@@ -1,152 +1,22 @@
 package permissions
-#
-# This is the set of policy definitions for the permissions engine.
-#
-
-#
-# Provided:
-# input = {
-#     'token': user token
-#     'method': method requested at data service
-#     'path': path to request at data service
-#     'program': name of program (optional)
-# }
-#
-import data.idp.valid_token as valid_token
-import data.idp.user_key as user_key
 import future.keywords.in
 
 #
-# This user is a site admin if they have the site_admin role
+# Values that are used by authx
 #
-import data.vault.site_roles as site_roles
-site_admin = true {
-    user_key in site_roles.admin
+valid_token := true {
+    data.idp.valid_token
 }
+else := false
 
-#
-# what programs are available to this user?
-#
-
-import data.vault.all_programs as all_programs
-import data.vault.program_auths as program_auths
-import data.vault.user_programs as user_programs
-
-# compile list of programs specifically authorized for the user by DACs and within the authorized time period
-user_readable_programs[p["program_id"]] := output {
-    some p in user_programs
-    time.parse_ns("2006-01-02", p["start_date"]) <= time.now_ns()
-    time.parse_ns("2006-01-02", p["end_date"]) >= time.now_ns()
-    output := p
-}
-
-# compile list of programs that list the user as a team member
-team_readable_programs[p] := output {
-    some p in all_programs
-    user_key in program_auths[p].team_members
-    output := program_auths[p].team_members
-}
-
-# user can read programs that are either team-readable or user-readable
-readable_programs := object.keys(object.union(team_readable_programs, user_readable_programs))
-
-# user can curate programs that list the user as a program curator
-curateable_programs[p] {
-    some p in all_programs
-    user_key in program_auths[p].program_curators
-}
-
-import data.vault.paths as paths
-
-# debugging
-valid_token := valid_token
-readable_get[p] := output {
-    some p in paths.read.get
-    output := regex.match(p, input.body.path)
-}
-readable_post[p] := output {
-    some p in paths.read.post
-    output := regex.match(p, input.body.path)
-}
-curateable_get[p] := output {
-    some p in paths.curate.get
-    output := regex.match(p, input.body.path)
-}
-curateable_post[p] := output {
-    some p in paths.curate.post
-    output := regex.match(p, input.body.path)
-}
-
-# which datasets can this user see for this method, path
-default datasets = []
-
-# site admins can see all programs
-datasets := all_programs
-{
-    site_admin
-}
-
-# if user is a team_member, they can access programs that allow read access for this method, path
-else := readable_programs
-{
+site_admin := data.calculate.site_admin {
     valid_token
-    input.body.method = "GET"
-    regex.match(paths.read.get[_], input.body.path) == true
 }
 
-else := readable_programs
-{
+datasets := data.calculate.datasets {
     valid_token
-    input.body.method = "POST"
-    regex.match(paths.read.post[_], input.body.path) == true
 }
-
-# if user is a site curator, they can access all programs that allow curate access for this method, path
-else := all_programs
-{
-    valid_token
-    user_key in site_roles.curator
-    input.body.method = "GET"
-    regex.match(paths.curate.get[_], input.body.path) == true
-}
-
-else := all_programs
-{
-    valid_token
-    user_key in site_roles.curator
-    input.body.method = "POST"
-    regex.match(paths.curate.post[_], input.body.path) == true
-}
-
-else := all_programs
-{
-    valid_token
-    user_key in site_roles.curator
-    input.body.method = "DELETE"
-    regex.match(paths.curate.delete[_], input.body.path) == true
-}
-
-# if user is a program_curator, they can access programs that allow curate access for them for this method, path
-else := curateable_programs
-{
-    valid_token
-    input.body.method = "GET"
-    regex.match(paths.curate.get[_], input.body.path) == true
-}
-
-else := curateable_programs
-{
-    valid_token
-    input.body.method = "POST"
-    regex.match(paths.curate.post[_], input.body.path) == true
-}
-
-else := curateable_programs
-{
-    valid_token
-    input.body.method = "DELETE"
-    regex.match(paths.curate.delete[_], input.body.path) == true
-}
+else := []
 
 # convenience path: if a specific program is in the body, allowed = true if that program is in datasets
 allowed := true
@@ -158,3 +28,49 @@ else := true
     site_admin
 }
 
+
+#
+# User information, for decision log
+#
+
+# information from the jwt
+user_key := data.idp.user_key
+issuer := data.idp.user_info.iss
+
+#
+# Debugging information for decision log
+#
+
+user_is_site_admin := true {
+    user_key in data.vault.site_roles.admin
+}
+else := false
+
+user_is_site_curator := true {
+    user_key in data.vault.site_roles.curator
+}
+else := false
+
+# true if the path and method in the input match something in paths.json
+path_method_registered := true {
+    input.body.method = "GET"
+    object.union(data.calculate.readable_get, data.calculate.curateable_get)[_]
+}
+else := true {
+    input.body.method = "POST"
+    object.union(data.calculate.readable_post, data.calculate.curateable_post)[_]
+}
+else := true {
+    input.body.method = "DELETE"
+    data.calculate.curateable_delete[_]
+}
+else := false
+
+# programs the user is listed as a team member for
+team_member_programs := object.keys(data.calculate.team_readable_programs)
+
+# programs the user is approved by dac for
+dac_programs := object.keys(data.vault.user_programs)
+
+# programs the user is listed as a program curator for
+curator_programs := data.calculate.curateable_programs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
 jq
 pytest==7.2.0
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.4.5
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.5.0
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.0

--- a/tests/test_opa_permissions.py
+++ b/tests/test_opa_permissions.py
@@ -188,6 +188,7 @@ def evaluate_opa(user, input, key, expected_result, site_roles, users, programs)
     args = [
         "./opa", "eval",
         "--data", "permissions_engine/authz.rego",
+        "--data", "permissions_engine/calculate.rego",
         "--data", "permissions_engine/permissions.rego",
     ]
     vault = setup_vault(user, site_roles, users, programs)
@@ -217,8 +218,8 @@ def evaluate_opa(user, input, key, expected_result, site_roles, users, programs)
                 print(json.dumps({"input": input}))
                 p = subprocess.run(args, stdout=subprocess.PIPE)
                 r =  json.loads(p.stdout)
-                print(r)
                 result =r['result'][0]['expressions'][0]['value']
+                print(result)
                 if key in result:
                     assert result[key] == expected_result
                 else:


### PR DESCRIPTION
I moved most of the actual calculations and logic of the decision making from permissions.rego to calculate.rego. However, calculate.rego only uses the decoded user_key from the token; it does not validate the token. 

An upcoming authx PR will switch to querying the permissions path itself and deriving the needed value from the results, so that the entire permissions structure will be logged in the decision log.

permissions.rego exposes some extra debugging information:
* user_key and issuer from the jwt, so we can see who was asking for permission
* valid_token, so we can separately see if the token was valid at decision time
* path_method_registered tells us whether or not the requested path/method combination is registered in paths.json
* dac_programs, team_member_programs, and curator_programs list the programs that the user is directly listed in, either in ProgramAuthorizations or in UserProgramAuthorizations
* user_is_site_admin and user_is_site_curator tell us if the user is listed in the site roles

`allowed`, `site_admin`, and `datasets` in the new permissions.rego use the values from calculate.rego use the values from calculate.rego but check for token validity as well. 

Finally, we are adding a mask.rego file to remove the whole token from the decision logs.

To see what I mean: clean/build/compose this branch, then do a query like 
```
curl -X "POST" "http://candig.docker.internal:5080/policy/v1/data/permissions" \
     -H 'Authorization: Bearer <site admin token>' \
     -H 'Content-Type: application/json' \
     -H 'Accept: application/json' \
     -d $'{
  "input": {
    "token": "some user token",
    "body": {
      "path": "/ga4gh/drs/v1/cohorts",
      "method": "GET",
      "program": "SYNTHETIC-1"
    }
  }
}'
```

You will get a result like
```
{
  "result": {
    "allowed": true,
    "curator_programs": [
      "SYNTHETIC-1",
      "SYNTH_01",
      "SYNTH_02"
    ],
    "dac_programs": [],
    "datasets": [
      "SYNTHETIC-1",
      "SYNTH_01",
      "SYNTH_02"
    ],
    "issuer": "http://candig.docker.internal:8080/auth/realms/candig",
    "path_method_registered": true,
    "site_admin": false,
    "team_member_programs": [
      "SYNTHETIC-1",
      "SYNTH_01",
      "SYNTH_02"
    ],
    "user_is_site_admin": false,
    "user_is_site_curator": false,
    "user_key": "user1@test.ca",
    "valid_token": true
  }
}
```