### PR TITLE
hotfix: site curator only relevant for curateable path/method

### DIFF
--- a/defaults/site_roles.json
+++ b/defaults/site_roles.json
@@ -4,14 +4,10 @@
             "SITE_ADMIN_USER"
         ],
         "curator": [
-            "USER2"
         ],
         "local_team": [
-            "USER1"
         ],
         "mohccn_network": [
-            "USER1",
-            "USER2"
         ]
     }
 }

--- a/permissions_engine/permissions.rego
+++ b/permissions_engine/permissions.rego
@@ -23,14 +23,30 @@ datasets := data.calculate.datasets {
 else := []
 
 
-# true if the path and method in the input match something in paths.json
-path_method_registered := true {
+# true if the path and method in the input match a readable combo in paths.json
+readable_method_path := true {
     input.body.method = "GET"
-    object.union(data.calculate.readable_get, data.calculate.curateable_get)[_]
+    data.calculate.readable_get[_]
 }
 else := true {
     input.body.method = "POST"
-    object.union(data.calculate.readable_post, data.calculate.curateable_post)[_]
+    data.calculate.readable_post[_]
+}
+else := true {
+    input.body.method = "DELETE"
+    data.calculate.curateable_delete[_]
+}
+else := false
+
+
+# true if the path and method in the input match a curateable combo in paths.json
+curateable_method_path := true {
+    input.body.method = "GET"
+    data.calculate.curateable_get[_]
+}
+else := true {
+    input.body.method = "POST"
+    data.calculate.curateable_post[_]
 }
 else := true {
     input.body.method = "DELETE"
@@ -53,7 +69,7 @@ else := true
 else := true
 {
     site_curator
-    path_method_registered
+    curateable_method_path
 }
 
 

--- a/permissions_engine/permissions.rego
+++ b/permissions_engine/permissions.rego
@@ -71,6 +71,11 @@ else := true
     site_curator
     curateable_method_path
 }
+else := true
+{
+    site_curator
+    readable_method_path
+}
 
 
 #


### PR DESCRIPTION
I noticed a failure in the integration tests: I need to separate the readable path/method combos from the curateable ones, and site curators are only allowed to curate curateable ones, regardless of program. This is how we can allow site curator to create non-existent programs without allowing them to read programs they're not authorized for. (Is this actually the behavior we want?)