### PR TITLE
Hotfix: curateable programs were not calculated properly for site curators

### DIFF
--- a/permissions_engine/calculate.rego
+++ b/permissions_engine/calculate.rego
@@ -60,16 +60,18 @@ readable_programs := all_programs if {
 
 else := object.keys(object.union(team_readable_programs, user_readable_programs))
 
-# user can curate programs that list the user as a program curator
+# programs that list the user as a program curator
 program_curateable_programs[p] if {
 	some p in all_programs
 	user_key in program_auths[p].program_curators
 }
 
+# if the user is a site curator, they can curate any program
 curateable_programs := all_programs if {
 	user_key in site_roles.curator
 }
 
+# otherwise, the user can curate programs where they're listed as a program curator
 else := program_curateable_programs
 
 import data.vault.paths as paths

--- a/permissions_engine/calculate.rego
+++ b/permissions_engine/calculate.rego
@@ -121,6 +121,10 @@ else := readable_programs if {
 
 # if user is a curator, they can access programs that allow curate access for them for this method, path
 else := curateable_programs if {
+	site_curator
+}
+
+else := curateable_programs if {
 	input.body.method = "GET"
 	regex.match(paths.curate.get[_], input.body.path) == true
 }

--- a/permissions_engine/calculate.rego
+++ b/permissions_engine/calculate.rego
@@ -54,13 +54,23 @@ team_readable_programs[p] := output if {
 }
 
 # user can read programs that are either team-readable or user-readable
-readable_programs := object.keys(object.union(team_readable_programs, user_readable_programs))
+readable_programs := all_programs if {
+	user_key in site_roles.curator
+}
+
+else := object.keys(object.union(team_readable_programs, user_readable_programs))
 
 # user can curate programs that list the user as a program curator
-curateable_programs[p] if {
+program_curateable_programs[p] if {
 	some p in all_programs
 	user_key in program_auths[p].program_curators
 }
+
+curateable_programs := all_programs if {
+	user_key in site_roles.curator
+}
+
+else := program_curateable_programs
 
 import data.vault.paths as paths
 
@@ -109,26 +119,7 @@ else := readable_programs if {
 	regex.match(paths.read.post[_], input.body.path) == true
 }
 
-# if user is a site curator, they can access all programs that allow curate access for this method, path
-else := all_programs if {
-	user_key in site_roles.curator
-	input.body.method = "GET"
-	regex.match(paths.curate.get[_], input.body.path) == true
-}
-
-else := all_programs if {
-	user_key in site_roles.curator
-	input.body.method = "POST"
-	regex.match(paths.curate.post[_], input.body.path) == true
-}
-
-else := all_programs if {
-	user_key in site_roles.curator
-	input.body.method = "DELETE"
-	regex.match(paths.curate.delete[_], input.body.path) == true
-}
-
-# if user is a program_curator, they can access programs that allow curate access for them for this method, path
+# if user is a curator, they can access programs that allow curate access for them for this method, path
 else := curateable_programs if {
 	input.body.method = "GET"
 	regex.match(paths.curate.get[_], input.body.path) == true

--- a/permissions_engine/permissions.rego
+++ b/permissions_engine/permissions.rego
@@ -137,4 +137,4 @@ team_member_programs := object.keys(data.calculate.team_readable_programs)
 dac_programs := object.keys(data.vault.user_programs)
 
 # programs the user is listed as a program curator for
-curator_programs := object.keys(data.calculate.curateable_programs)
+curator_programs := object.keys(data.calculate.program_curateable_programs)

--- a/tests/test_opa_permissions.py
+++ b/tests/test_opa_permissions.py
@@ -96,13 +96,13 @@ def users():
             "user": {
                 "user_name": "user1@test.ca"
             },
-            "programs": [
-                {
+            "programs": {
+                "SYNTHETIC-1": {
                     "program_id": "SYNTHETIC-1",
                     "start_date": THE_PAST,
                     "end_date": THE_FUTURE
                 }
-            ]
+            }
         },
         "user2": {
             # user2 is curator for SYNTHETIC-2
@@ -110,18 +110,18 @@ def users():
             "user": {
                 "user_name": "user2@test.ca"
             },
-            "programs": [
-                {
+            "programs": {
+                "SYNTHETIC-1": {
                     "program_id": "SYNTHETIC-1",
                     "start_date": THE_PAST,
                     "end_date": THE_FUTURE
                 },
-                {
+                "SYNTHETIC-4": {
                     "program_id": "SYNTHETIC-4",
                     "start_date": THE_PAST,
                     "end_date": THE_FUTURE
                 }
-            ]
+            }
         },
         "user3": {
             # user3 is curator for SYNTHETIC-3
@@ -129,30 +129,30 @@ def users():
             "user": {
                 "user_name": "user3@test.ca"
             },
-            "programs": [
-                { # this program is already OVER
+            "programs": {
+                "SYNTHETIC-1": { # this program is already OVER
                     "program_id": "SYNTHETIC-1",
                     "start_date": THE_PAST,
                     "end_date": THE_PAST
                 },
-                {
+                "SYNTHETIC-4": {
                     "program_id": "SYNTHETIC-4",
                     "start_date": THE_PAST,
                     "end_date": THE_FUTURE
                 }
-            ]
+            }
         },
         "dac_user": {
             "user": {
                 "user_name": "dac_user@test.ca"
             },
-            "programs": [
-                {
+            "programs": {
+                "SYNTHETIC-3": {
                     "program_id": "SYNTHETIC-3",
                     "start_date": THE_PAST,
                     "end_date": THE_FUTURE
                 }
-            ]
+            }
         },
         "user_not_authz": {
             # user_not_authz is not candig-authorized
@@ -164,7 +164,7 @@ def users():
             "user": {
                 "user_name": "site_admin@test.ca"
             },
-            "programs": []
+            "programs": {}
         },
 
     }
@@ -267,6 +267,16 @@ def get_user_datasets():
             "user1",
             {"body": {"path": "/v3/discovery/programs/", "method": "GET"}},
             ["SYNTHETIC-1", "SYNTHETIC-3", "SYNTHETIC-4"],
+        ),
+        (  # user2 can view all datasets because they're a site curator
+            "user2",
+            {"body": {"path": "/v3/authorized/programs/", "method": "GET"}},
+            ["SYNTHETIC-1", "SYNTHETIC-2", "SYNTHETIC-3", "SYNTHETIC-4"],
+        ),
+        (  # user2 can view all datasets because they're a site curator
+            "user2",
+            {"body": {"path": None, "method": None}},
+            ["SYNTHETIC-1", "SYNTHETIC-2", "SYNTHETIC-3", "SYNTHETIC-4"],
         ),
         (  # user3 can view the datasets it's a member of + DAC programs,
             # but SYNTHETIC-1's authorized dates are in the past


### PR DESCRIPTION
When there is no body specified, the curateable programs would default to the empty set. Of the two new tests, the first passed without these changes, but the second would not pass. Now they both do.