### PR TITLE
clarifying decision logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,44 @@ Authorization to endpoints in the OPA service itself is defined in [authz.rego](
   * Authorizations for roles in particular programs: users defined as team_members for a program are allowed to access the read paths specified in [paths.json](defaults/paths.json), while users defined as program_curators are allowed to access the curate and delete paths. Note: read and curate paths are separately allowed: if a user should be allowed to both read and curate, they should be in both the team_members and program_curators groups. Program authorizations can be created, edited, and deleted through the ingest microservice. Default test examples can be found in [programs.json](defaults/programs.json).
 
   * Users can also be specifically authorized to read data for a particular program through a data access authorization. User Read authorizations can be created, edited, and revoked through the ingest microservice.
+
+
+The OPA response from the `permissions` endpoint contains the information used by OPA to resolve the permission question. It is used in two ways:
+  * The authx library parses this response and returns a result. For example, in the `is_site_admin` method, authx returns `response.json()["result"]["site_admin"]` (in the example below, this is false).
+  * The decision log is added to the CanDIG logs for future auditing. The dictionary `debug` contains extra information that may help diagnose why permissions weren't assigned as expected.
+
+```
+{
+  "decision_id": "7f38aeb3-5902-42ad-b2a6-f45f000e37c2",
+  "result": {
+    "allowed": true,
+    "curateable_method_path": true,
+    "datasets": [
+      "LOCAL-SYNTH_01",
+      "SYNTH_04"
+    ],
+    "debug": {
+      "local_issuer": "http://candig.docker.internal:8080/auth/realms/candig",
+      "user_key_has_curator_programs": [
+        "LOCAL-SYNTH_01"
+      ],
+      "user_key_has_dac_programs": [
+        "SYNTH_04"
+      ],
+      "user_key_has_team_member_programs": [
+        "LOCAL-SYNTH_01"
+      ],
+      "user_key_listed_as_site_admin": false,
+      "user_key_listed_as_site_curator": false
+    },
+    "is_local_token": true,
+    "issuer": "http://candig.docker.internal:8080/auth/realms/candig",
+    "readable_method_path": true,
+    "site_admin": false,
+    "site_curator": false,
+    "user_is_candig_authorized": true,
+    "user_key": "user1@test.ca",
+    "valid_token": true
+  }
+}
+```

--- a/permissions_engine/permissions.rego
+++ b/permissions_engine/permissions.rego
@@ -22,10 +22,14 @@ site_admin := data.calculate.site_admin if {
 	is_local_token
 }
 
+else := false
+
 site_curator := data.calculate.site_curator if {
 	valid_token
 	is_local_token
 }
+
+else := false
 
 datasets := data.calculate.datasets if {
 	valid_token
@@ -99,6 +103,8 @@ else if {
 	readable_method_path
 }
 
+else := false
+
 #
 # User information, for decision log
 #
@@ -108,33 +114,35 @@ user_key := data.idp.user_key
 
 issuer := data.idp.user_info.iss
 
-#
-# Debugging information for decision log
-#
-
-user_is_site_admin if {
-	user_key in data.vault.site_roles.admin
-}
-
-else := false
-
-user_is_site_curator if {
-	user_key in data.vault.site_roles.curator
-}
-
-else := false
-
 user_is_candig_authorized if {
 	data.vault.user_auth.status_code == 200
 }
 
 else := false
 
+#
+# Debugging information for decision log
+#
+
+debug.local_issuer := data.vault.keys[0].iss
+
+debug.user_key_listed_as_site_admin if {
+	user_key in data.vault.site_roles.admin
+}
+
+else := false
+
+debug.user_key_listed_as_site_curator if {
+	user_key in data.vault.site_roles.curator
+}
+
+else := false
+
 # programs the user is listed as a team member for
-team_member_programs := object.keys(data.calculate.team_readable_programs)
+debug.user_key_has_team_member_programs := object.keys(data.calculate.team_readable_programs)
 
 # programs the user is approved by dac for
-dac_programs := object.keys(data.vault.user_programs)
+debug.user_key_has_dac_programs := object.keys(data.vault.user_programs)
 
 # programs the user is listed as a program curator for
-curator_programs := object.keys(data.calculate.program_curateable_programs)
+debug.user_key_has_curator_programs := object.keys(data.calculate.program_curateable_programs)


### PR DESCRIPTION
Based on suggestions from Slack, I've added some clarifications to the output of permissions.rego to make the decision log easier to understand. The new format:
```
{
  "decision_id": "7f38aeb3-5902-42ad-b2a6-f45f000e37c2",
  "result": {
    "allowed": true,
    "curateable_method_path": true,
    "datasets": [
      "LOCAL-SYNTH_01",
      "SYNTH_04"
    ],
    "debug": {
      "local_issuer": "http://candig.docker.internal:8080/auth/realms/candig",
      "user_key_has_curator_programs": [
        "LOCAL-SYNTH_01"
      ],
      "user_key_has_dac_programs": [
        "SYNTH_04"
      ],
      "user_key_has_team_member_programs": [
        "LOCAL-SYNTH_01"
      ],
      "user_key_listed_as_site_admin": false,
      "user_key_listed_as_site_curator": false
    },
    "is_local_token": true,
    "issuer": "http://candig.docker.internal:8080/auth/realms/candig",
    "readable_method_path": true,
    "site_admin": false,
    "site_curator": false,
    "user_is_candig_authorized": true,
    "user_key": "user1@test.ca",
    "valid_token": true
  }
}
```

Debugging values are broken out into their own `debug` sub-dict and the values of all booleans, like `site_admin`, `site_curator`, and `allowed`, are set to False if not otherwise specified.