### PR TITLE
DIG-2016: allow curators to read data

### DIFF
--- a/defaults/paths.json
+++ b/defaults/paths.json
@@ -22,11 +22,24 @@
         },
         "curate": {
             "get": [
+                "/v3/discovery/?.*",
+                "/v3/authorized/?.*",
+                "/htsget/v1/variants/?.*",
+                "/htsget/v1/variants/search",
+                "/htsget/v1/reads/?.*",
+                "/htsget/v1/samples/?.*",
+                "/ga4gh/drs/v1/objects/?.*",
+                "/ga4gh/drs/v1/programs/?.*",
+                "/ga4gh/drs/v1/programs/?.*/status",
+                "/beacon/v2/g_variants/?.*",
                 "/ingest/?.*",
                 "/htsget/v1/?.*/index",
                 "/htsget/v1/?.*/verify"
             ],
             "post": [
+                "/htsget/v1/variants/search",
+                "/htsget/v1/samples",
+                "/beacon/v2/g_variants",
                 "/ingest/s3-credential/?.*",
                 "/ingest/program/?.*",
                 "/ingest/user/?.*",

--- a/initialize_vault_store.py
+++ b/initialize_vault_store.py
@@ -7,14 +7,14 @@ import sys
 results = []
 
 try:
-    response, status_code = get_service_store_secret("opa", key="paths")
-    if status_code != 200:
-        with open('/app/defaults/paths.json') as f:
-            data = f.read()
-            response, status_code = set_service_store_secret("opa", key="paths", value=data)
-            if status_code != 200:
-                raise Exception(f"failed to save paths: {response} {status_code}")
-            results.append(response)
+    # response, status_code = get_service_store_secret("opa", key="paths")
+    # if status_code != 200:
+    with open('/app/defaults/paths.json') as f:
+        data = f.read()
+        response, status_code = set_service_store_secret("opa", key="paths", value=data)
+        if status_code != 200:
+            raise Exception(f"failed to save paths: {response} {status_code}")
+        results.append(response)
 
     response, status_code = get_service_store_secret("opa", key="site_roles")
     if status_code != 200:

--- a/permissions_engine/calculate.rego
+++ b/permissions_engine/calculate.rego
@@ -34,16 +34,17 @@ site_curator if {
 # what programs are available to this user?
 #
 
-import data.vault.all_programs as all_programs
 import data.vault.program_auths as program_auths
 import data.vault.user_programs as user_programs
 
+# convert this to be a set, not an array
+all_programs := {x | x := data.vault.all_programs[_]}
+
 # compile list of programs specifically authorized for the user by DACs and within the authorized time period
-user_readable_programs[p.program_id] := output if {
+user_readable_programs contains p.program_id if {
 	some p in user_programs
 	time.parse_ns("2006-01-02", p.start_date) <= time.now_ns()
 	time.parse_ns("2006-01-02", p.end_date) >= time.now_ns()
-	output := p
 }
 
 # compile list of programs that list the user as a team member
@@ -57,7 +58,7 @@ readable_programs := all_programs if {
 	user_key in site_roles.curator
 }
 
-else := object.keys(object.union(team_readable_programs, user_readable_programs))
+else := team_readable_programs | user_readable_programs
 
 # programs that list the user as a program curator
 program_curateable_programs contains p if {
@@ -101,6 +102,8 @@ curateable_delete[p] := output if {
 	output := regex.match(p, input.body.path)
 }
 
+accessible_programs := curateable_programs | readable_programs
+
 # which datasets can this user see for this method, path
 default datasets := []
 
@@ -110,21 +113,21 @@ datasets := all_programs if {
 }
 
 # if user is a curator, they can access programs that allow curate access for them for this method, path
-else := curateable_programs | readable_programs if {
+else := accessible_programs if {
 	site_curator
 }
 
-else := curateable_programs | readable_programs if {
+else := accessible_programs if {
 	input.body.method = "GET"
 	regex.match(paths.curate.get[_], input.body.path) == true
 }
 
-else := curateable_programs | readable_programs if {
+else := accessible_programs if {
 	input.body.method = "POST"
 	regex.match(paths.curate.post[_], input.body.path) == true
 }
 
-else := curateable_programs | readable_programs if {
+else := accessible_programs if {
 	input.body.method = "DELETE"
 	regex.match(paths.curate.delete[_], input.body.path) == true
 }

--- a/permissions_engine/calculate.rego
+++ b/permissions_engine/calculate.rego
@@ -47,10 +47,9 @@ user_readable_programs[p.program_id] := output if {
 }
 
 # compile list of programs that list the user as a team member
-team_readable_programs[p] := output if {
+team_readable_programs contains p if {
 	some p in all_programs
 	user_key in program_auths[p].team_members
-	output := program_auths[p].team_members
 }
 
 # user can read programs that are either team-readable or user-readable
@@ -61,7 +60,7 @@ readable_programs := all_programs if {
 else := object.keys(object.union(team_readable_programs, user_readable_programs))
 
 # programs that list the user as a program curator
-program_curateable_programs[p] if {
+program_curateable_programs contains p if {
 	some p in all_programs
 	user_key in program_auths[p].program_curators
 }

--- a/permissions_engine/calculate.rego
+++ b/permissions_engine/calculate.rego
@@ -109,33 +109,22 @@ datasets := all_programs if {
 	site_admin
 }
 
-# if user is a team_member, they can access programs that allow read access for this method, path
-else := readable_programs if {
-	input.body.method = "GET"
-	regex.match(paths.read.get[_], input.body.path) == true
-}
-
-else := readable_programs if {
-	input.body.method = "POST"
-	regex.match(paths.read.post[_], input.body.path) == true
-}
-
 # if user is a curator, they can access programs that allow curate access for them for this method, path
-else := curateable_programs if {
+else := curateable_programs | readable_programs if {
 	site_curator
 }
 
-else := curateable_programs if {
+else := curateable_programs | readable_programs if {
 	input.body.method = "GET"
 	regex.match(paths.curate.get[_], input.body.path) == true
 }
 
-else := curateable_programs if {
+else := curateable_programs | readable_programs if {
 	input.body.method = "POST"
 	regex.match(paths.curate.post[_], input.body.path) == true
 }
 
-else := curateable_programs if {
+else := curateable_programs | readable_programs if {
 	input.body.method = "DELETE"
 	regex.match(paths.curate.delete[_], input.body.path) == true
 }

--- a/permissions_engine/permissions.rego
+++ b/permissions_engine/permissions.rego
@@ -139,10 +139,10 @@ debug.user_key_listed_as_site_curator if {
 else := false
 
 # programs the user is listed as a team member for
-debug.user_key_has_team_member_programs := object.keys(data.calculate.team_readable_programs)
+debug.user_key_has_team_member_programs := data.calculate.team_readable_programs
 
 # programs the user is approved by dac for
 debug.user_key_has_dac_programs := object.keys(data.vault.user_programs)
 
 # programs the user is listed as a program curator for
-debug.user_key_has_curator_programs := object.keys(data.calculate.program_curateable_programs)
+debug.user_key_has_curator_programs := data.calculate.program_curateable_programs


### PR DESCRIPTION
It seems to me to be the most straightforward to add the read paths to curate as well, so that if, for some reason, we run into a weird case where a team member does need to do something that a program curator can't do, we can still maintain the separation.

I also updated some arrays to be sets and tightened up the logic for which programs should be accessible.