### PR TITLE
DHDPS-401: validate external service token

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,7 @@ set -Euo pipefail
 if [[ -f "/app/initial_setup" ]]; then
     # set up our default values
     sed -i s/CANDIG_USER_KEY/$CANDIG_USER_KEY/ /app/permissions_engine/idp.rego
+    sed -i s/KEYCLOAK_CLIENT_ID/$KEYCLOAK_CLIENT_ID/ /app/permissions_engine/idp.rego
 
     # set up default users in default jsons:
     sed -i s/SITE_ADMIN_USER/$SITE_ADMIN_USER/ /app/defaults/site_roles.json

--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -86,7 +86,7 @@ services := data.vault.external_services
 
 is_external_service[i] if {
 	some i in object.keys(services)
-	services[i].user == decode_verify_token_output[_][2].CANDIG_USER_KEY
+#	services[i].user == decode_verify_token_output[_][2].CANDIG_USER_KEY
 	services[i].issuer == decode_verify_token_output[_][2].iss
 	services[i].client_id == decode_verify_token_output[_][2].azp
 }

--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -86,7 +86,7 @@ services := data.vault.external_services
 
 is_external_service[i] if {
 	some i in object.keys(services)
-	services[i].user == decode_verify_token_output[_][2].sub
-	services[i].authentication.issuer == decode_verify_token_output[_][2].iss
+	services[i].user == decode_verify_token_output[_][2].CANDIG_USER_KEY
+	services[i].issuer == decode_verify_token_output[_][2].iss
 	services[i].client_id == decode_verify_token_output[_][2].azp
 }

--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -16,13 +16,12 @@ import rego.v1
 decode_verify_token(key, token) := output if {
 	issuer := key.iss
 	cert := key.cert
-	aud := key.aud[_]
 	output := io.jwt.decode_verify(
 		token, # Decode and verify in one-step
 		{
 			"cert": cert, # With the supplied constraints:
 			"iss": issuer,
-			"aud": aud,
+			"aud": "KEYCLOAK_CLIENT_ID",
 		},
 	)
 }
@@ -44,7 +43,7 @@ user_info := decoded_output[1]
 user_key := user_info.CANDIG_USER_KEY
 
 #
-# If either input.identity or input.token are valid against an issuer, decode and verify
+# If input.token is valid against an issuer, decode and verify
 #
 decode_verify_token_output[issuer] := output if {
 	possible_tokens := ["identity", "token"]

--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -81,6 +81,7 @@ is_local_token if {
 	keys[0].iss == token_issuer
 }
 
+# we can tell if a token is from an external service if it matches the claims of a registered external service
 services := data.vault.external_services
 
 is_external_service[i] if {

--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -81,3 +81,12 @@ trusted_researcher if {
 is_local_token if {
 	keys[0].iss == token_issuer
 }
+
+services := data.vault.external_services
+
+is_external_service[i] if {
+	some i in object.keys(services)
+	services[i].user == decode_verify_token_output[_][2].sub
+	services[i].authentication.issuer == decode_verify_token_output[_][2].iss
+	services[i].client_id == decode_verify_token_output[_][2].azp
+}

--- a/permissions_engine/service.rego
+++ b/permissions_engine/service.rego
@@ -10,6 +10,10 @@ verified if {
 	service_token == input.token
 }
 
+else if {
+	data.idp.is_external_service[input.service] == true
+}
+
 else := false
 
 

--- a/permissions_engine/vault.rego
+++ b/permissions_engine/vault.rego
@@ -30,6 +30,7 @@ program_auths[p] := program if {
 # check to see if the user is authorized for any other programs via DACs
 user_auth := http.send({"method": "get", "url": concat("/", ["VAULT_URL/v1/opa/users", urlquery.encode(user_key)]), "headers": {"X-Vault-Token": vault_token}, "raise_error": false})
 
+# external services are registered in federation's vault store
 external_services := http.send({"method": "get", "url": concat("/", ["VAULT_URL/v1/federation/external_services"]), "headers": {"X-Vault-Token": vault_token}, "raise_error": false}).body.data.external_services
 
 default user_programs := []

--- a/permissions_engine/vault.rego
+++ b/permissions_engine/vault.rego
@@ -30,6 +30,8 @@ program_auths[p] := program if {
 # check to see if the user is authorized for any other programs via DACs
 user_auth := http.send({"method": "get", "url": concat("/", ["VAULT_URL/v1/opa/users", urlquery.encode(user_key)]), "headers": {"X-Vault-Token": vault_token}, "raise_error": false})
 
+external_services := http.send({"method": "get", "url": concat("/", ["VAULT_URL/v1/federation/external_services"]), "headers": {"X-Vault-Token": vault_token}, "raise_error": false}).body.data.external_services
+
 default user_programs := []
 
 user_programs := user_auth.body.data.dac_authorizations if {


### PR DESCRIPTION
The service/verify endpoint now can examine tokens from registered external services: if the token is valid (and contains the CanDIG node's KEYCLOAK_CLIENT_ID in its `aud` claim), we can see if it comes from a registered external service, and if so, see if it's verified.

Tested in https://github.com/CanDIG/CanDIGv2/pull/1128.