### PR TITLE
DIG-2084: update idp.rego to match the DHDP use case

### DIFF
--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -13,7 +13,7 @@ import rego.v1
 #
 # Function to decode and verify if a token is valid against a key
 #
-decode_verify_token(key, token) := output if {
+decode_verify_token(key, token, aud) := output if {
 	issuer := key.iss
 	cert := key.cert
 	output := io.jwt.decode_verify(
@@ -21,7 +21,7 @@ decode_verify_token(key, token) := output if {
 		{
 			"cert": cert, # With the supplied constraints:
 			"iss": issuer,
-			"aud": "KEYCLOAK_CLIENT_ID",
+			"aud": aud,
 		},
 	)
 }
@@ -49,7 +49,9 @@ decode_verify_token_output[issuer] := output if {
 	possible_tokens := ["identity", "token"]
 	some i
 	issuer := keys[i].iss
-	output := decode_verify_token(keys[i], input[possible_tokens[_]])
+	some j
+	aud := keys[i].aud[j]
+	output := decode_verify_token(keys[i], input[possible_tokens[_]], aud)
 }
 
 #

--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -81,6 +81,7 @@ trusted_researcher if {
 #
 is_local_token if {
 	keys[0].iss == token_issuer
+	user_info.azp == "KEYCLOAK_CLIENT_ID"
 }
 
 # we can tell if a token is from an external service if it matches the claims of a registered external service

--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -45,7 +45,7 @@ user_key := user_info.CANDIG_USER_KEY
 #
 # If input.token is valid against an issuer, decode and verify
 #
-decode_verify_token_output[issuer] := output if {
+decode_verify_token_output[issuer][aud] := output if {
 	possible_tokens := ["identity", "token"]
 	some i
 	issuer := keys[i].iss
@@ -59,21 +59,21 @@ decode_verify_token_output[issuer] := output if {
 #
 token_issuer := i if {
 	some i in object.keys(decode_verify_token_output)
-	decode_verify_token_output[i][0] == true
+	decode_verify_token_output[i][_][0] == true
 }
 
 #
 # Check if token is valid by checking whether decoded_verify output exists or not
 #
 valid_token if {
-	decode_verify_token_output[_][0]
+	decode_verify_token_output[_][_][0]
 }
 
 #
 # Check trusted_researcher in the token payload
 #
 trusted_researcher if {
-	decode_verify_token_output[_][2].trusted_researcher == "true"
+	decode_verify_token_output[_][_][2].trusted_researcher == "true"
 }
 
 #
@@ -89,7 +89,7 @@ services := data.vault.external_services
 
 is_external_service[i] if {
 	some i in object.keys(services)
-#	services[i].user == decode_verify_token_output[_][2].CANDIG_USER_KEY
-	services[i].issuer == decode_verify_token_output[_][2].iss
-	services[i].client_id == decode_verify_token_output[_][2].azp
+#	services[i].user == decode_verify_token_output[_][_][2].CANDIG_USER_KEY
+	services[i].issuer == decode_verify_token_output[_][_][2].iss
+	services[i].client_id == decode_verify_token_output[_][_][2].azp
 }


### PR DESCRIPTION
On DHDP, all federated nodes share a Keycloak server but use different OIDC clients. Therefore, idp.rego cannot assume that the `KEYCLOAK_CLIENT_ID` defined in .env will be the only value of `aud` for a particular issuer, and we can't assume that any token issued by the first listed issuer is a token from the local node.

Therefore, when checking token validity, a token is valid if it comes from an issuer and any of its known audiences, and a token is local if it has the local .env `KEYCLOAK_CLIENT_ID` in the token's `azp` field.