### PR TITLE
Bump candig-logging version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests>=2.32.3
 jq>=1.8.0
 pytest>=8.3.3
 candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.3
-candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
+candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.3


### PR DESCRIPTION
Vulnerability found with Dependabot in candig-logging, so we've got to bump the version everywhere