### PR TITLE
DIG-2096: Adding DAC authorizations to users that have never logged in

### DIFF
--- a/permissions_engine/idp.rego
+++ b/permissions_engine/idp.rego
@@ -40,7 +40,11 @@ user_info := decoded_output[1]
 #
 # The user's key, as determined by this candig instance
 #
-user_key := user_info.CANDIG_USER_KEY
+user_key := user_info.CANDIG_USER_KEY if {
+	user_info.CANDIG_USER_KEY
+}
+else := input.body.user_key
+
 
 #
 # If input.token is valid against an issuer, decode and verify

--- a/permissions_engine/permissions.rego
+++ b/permissions_engine/permissions.rego
@@ -116,6 +116,7 @@ issuer := data.idp.user_info.iss
 
 user_is_candig_authorized if {
 	data.vault.user_auth.status_code == 200
+	data.vault.user_auth.body.data.userinfo.sample_jwt
 }
 
 else := false

--- a/tests/test_opa_permissions.py
+++ b/tests/test_opa_permissions.py
@@ -178,7 +178,7 @@ def setup_vault(user, site_roles, users, programs):
     user_read_auth = users[user]
     if "programs" in user_read_auth:
         vault["vault"]["user_programs"] = user_read_auth["programs"]
-        vault["vault"]["user_auth"] = {"status_code": 200}
+        vault["vault"]["user_auth"] = {"body": {"data": {"userinfo": {"sample_jwt": "something"}}}, "status_code": 200}
     else:
         vault["vault"]["user_programs"] = []
         vault["vault"]["user_auth"] = {"status_code": 403}


### PR DESCRIPTION
Two changes here:
* It is possible for a user to exist in Vault but not to be candig-authorized, so we add a check for the sample_jwt as proof that they've logged in before.
* Site admin users should be able to get permissions information about a user without using a jwt, by providing the user_key directly.

I also updated the test to have a sample_jwt key in it.

Testing is done in https://github.com/CanDIG/CanDIGv2/pull/1166