### PR TITLE
Update authx for Minio>=7.2.19 in stable v7.0.1_hotfix.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.32.4
 jq>=1.8.0
 pytest>=8.3.3
-candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.6
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.7
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.3


### PR DESCRIPTION
Update candigv2-authx to work with Minio>=7.2.19.