### PR TITLE
DIG-2184: Shouldn't duplicate paths in curate and read in paths.json

### DIFF
--- a/defaults/paths.json
+++ b/defaults/paths.json
@@ -2,8 +2,6 @@
     "paths": {
         "read": {
             "get": [
-                "/v3/discovery/?.*",
-                "/v3/authorized/?.*",
                 "/v1/datasets",
                 "/v1/datasets/?.*",
                 "/v1/datasets/?.*/info",
@@ -11,6 +9,8 @@
                 "/v1/datasets/?.*/persons",
                 "/v1/datasets/?.*/persons/?.*",
                 "/v1/beacon/datasets/?.*",
+                "/v3/discovery/?.*",
+                "/v3/authorized/?.*",
                 "/htsget/v1/variants/?.*",
                 "/htsget/v1/variants/search",
                 "/htsget/v1/reads/?.*",
@@ -38,18 +38,9 @@
                 "/v1/authz/site-role/?.*",
                 "/v1/authz/user/?.*",
                 "/ingest/?.*",
-                "/v3/discovery/?.*",
-                "/v3/authorized/?.*",
-                "/ga4gh/drs/v1/objects/?.*",
-                "/ga4gh/drs/v1/programs/?.*",
                 "/ga4gh/drs/v1/programs/?.*/status",
-                "/htsget/v1/variants/?.*",
-                "/htsget/v1/variants/search",
-                "/htsget/v1/reads/?.*",
-                "/htsget/v1/samples/?.*",
                 "/htsget/v1/?.*/index",
-                "/htsget/v1/?.*/verify",
-                "/beacon/v2/g_variants/?.*"
+                "/htsget/v1/?.*/verify"
             ],
             "post": [
                 "/v1/authz/program",
@@ -63,10 +54,7 @@
                 "/ingest/?.*",
                 "/v3/ingest/?.*",
                 "/v3/download/?.*",
-                "/ga4gh/drs/v1/?.*",
-                "/htsget/v1/variants/search",
-                "/htsget/v1/samples",
-                "/beacon/v2/g_variants"
+                "/ga4gh/drs/v1/?.*"
             ],
             "put": [
                 "/v1/datasets",

--- a/defaults/paths.json
+++ b/defaults/paths.json
@@ -4,6 +4,13 @@
             "get": [
                 "/v3/discovery/?.*",
                 "/v3/authorized/?.*",
+                "/v1/datasets",
+                "/v1/datasets/?.*",
+                "/v1/datasets/?.*/info",
+                "/v1/datasets/?.*/statistics",
+                "/v1/datasets/?.*/persons",
+                "/v1/datasets/?.*/persons/?.*",
+                "/v1/beacon/datasets/?.*",
                 "/htsget/v1/variants/?.*",
                 "/htsget/v1/variants/search",
                 "/htsget/v1/reads/?.*",
@@ -14,46 +21,71 @@
                 "/beacon/v2/g_variants/?.*"
             ],
             "post": [
+                "/v1/beacon/?.*",
+                "/v3/download/?.*",
                 "/htsget/v1/variants/search",
                 "/htsget/v1/samples",
-                "/beacon/v2/g_variants",
-                "/v3/download/?.*"
+                "/beacon/v2/g_variants"
             ]
         },
         "curate": {
             "get": [
+                "/v1/authz/get-token",
+                "/v1/authz/program",
+                "/v1/authz/program/?.*",
+                "/v1/authz/program/?.*/dac_authorization",
+                "/v1/authz/s3-credential/?.*",
+                "/v1/authz/site-role/?.*",
+                "/v1/authz/user/?.*",
+                "/ingest/?.*",
                 "/v3/discovery/?.*",
                 "/v3/authorized/?.*",
+                "/ga4gh/drs/v1/objects/?.*",
+                "/ga4gh/drs/v1/programs/?.*",
+                "/ga4gh/drs/v1/programs/?.*/status",
                 "/htsget/v1/variants/?.*",
                 "/htsget/v1/variants/search",
                 "/htsget/v1/reads/?.*",
                 "/htsget/v1/samples/?.*",
-                "/ga4gh/drs/v1/objects/?.*",
-                "/ga4gh/drs/v1/programs/?.*",
-                "/ga4gh/drs/v1/programs/?.*/status",
-                "/beacon/v2/g_variants/?.*",
-                "/ingest/?.*",
                 "/htsget/v1/?.*/index",
-                "/htsget/v1/?.*/verify"
+                "/htsget/v1/?.*/verify",
+                "/beacon/v2/g_variants/?.*"
             ],
             "post": [
-                "/htsget/v1/variants/search",
-                "/htsget/v1/samples",
-                "/beacon/v2/g_variants",
+                "/v1/authz/program",
+                "/v1/authz/s3-credential",
+                "/v1/authz/site-role/?.*",
+                "/v1/authz/user/?.*",
+                "/v1/datasets/upload",
                 "/ingest/s3-credential/?.*",
                 "/ingest/program/?.*",
                 "/ingest/user/?.*",
                 "/ingest/?.*",
-                "/ga4gh/drs/v1/?.*",
                 "/v3/ingest/?.*",
-                "/v3/download/?.*"
+                "/v3/download/?.*",
+                "/ga4gh/drs/v1/?.*",
+                "/htsget/v1/variants/search",
+                "/htsget/v1/samples",
+                "/beacon/v2/g_variants"
+            ],
+            "put": [
+                "/v1/datasets",
+                "/v1/datasets/?.*"
+            ],
+            "patch": [
+                "/v1/datasets/?.*"
             ],
             "delete": [
+                "/v1/authz/program/?.*",
+                "/v1/authz/s3-credential/?.*",
+                "/v1/authz/site-role/?.*",
+                "/v1/authz/user/?.*",
+                "/v1/datasets/?.*",
                 "/ingest/s3-credential/?.*",
                 "/ingest/program/?.*",
                 "/ingest/user/?.*",
-                "/ga4gh/drs/v1/?.*",
-                "/v3/ingest/?.*"
+                "/v3/ingest/?.*",
+                "/ga4gh/drs/v1/?.*"
             ]
         }
     }

--- a/permissions_engine/calculate.rego
+++ b/permissions_engine/calculate.rego
@@ -131,3 +131,13 @@ else := accessible_programs if {
 	input.body.method = "DELETE"
 	regex.match(paths.curate.delete[_], input.body.path) == true
 }
+
+else := readable_programs if {
+	input.body.method = "GET"
+	regex.match(paths.read.get[_], input.body.path) == true
+}
+
+else := readable_programs if {
+	input.body.method = "POST"
+	regex.match(paths.read.post[_], input.body.path) == true
+}


### PR DESCRIPTION
While updating paths for candig-api, I noticed that I seem to have solved the problem of having readable GET paths return readable programs by just duplicating the readable GET paths into the curate section. That isn’t right.

To fix this: in calculate.rego, if the path in question is a readable GET path, datasets should include their readable programs. 

The pytest tests should still pass.